### PR TITLE
Add export-property-tile-info and generate-property-map-tiles tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ data/
 
 # Sensitive files
 keys/
+
+# AI
+.claude/worktrees/

--- a/tasks/data-pipeline/workflow.yaml
+++ b/tasks/data-pipeline/workflow.yaml
@@ -72,6 +72,14 @@ main:
             type: OIDC
           timeout: 540
 
+    - transform_tax_year_assessment_bins:
+        call: http.get
+        args:
+          url: "https://us-east4-musa5090s26-team6.cloudfunctions.net/transform-tax-year-assessment-bins"
+          auth:
+            type: OIDC
+          timeout: 540
+
     - export_property_tile_info:
         call: http.get
         args:

--- a/tasks/data-pipeline/workflow.yaml
+++ b/tasks/data-pipeline/workflow.yaml
@@ -71,3 +71,19 @@ main:
           auth:
             type: OIDC
           timeout: 540
+
+    - export_property_tile_info:
+        call: http.get
+        args:
+          url: "https://us-east4-musa5090s26-team6.cloudfunctions.net/export-property-tile-info"
+          auth:
+            type: OIDC
+          timeout: 540
+
+    - generate_property_map_tiles:
+        call: http.post
+        args:
+          url: "https://us-east4-run.googleapis.com/v2/projects/musa5090s26-team6/locations/us-east4/jobs/generate-property-map-tiles:run"
+          auth:
+            type: OAuth2
+          timeout: 1800

--- a/tasks/export-property-tile-info/derived_property_tile_info.sql
+++ b/tasks/export-property-tile-info/derived_property_tile_info.sql
@@ -1,0 +1,28 @@
+CREATE OR REPLACE TABLE `derived.property_tile_info` AS (
+    WITH latest_tax_year AS (
+        SELECT MAX(tax_year) AS max_year
+        FROM `core.opa_assessments`
+    ),
+    latest_assessments AS (
+        SELECT
+            property_id,
+            assessed_value AS tax_year_assessed_value
+        FROM `core.opa_assessments`
+        WHERE tax_year = (SELECT max_year FROM latest_tax_year)
+    )
+    SELECT
+        o.property_id,
+        o.location AS address,
+        par.geometry AS geog,
+        ca.assessed_value AS current_assessed_value,
+        la.tax_year_assessed_value
+    FROM `core.opa_properties` AS o
+    JOIN `core.pwd_parcels` AS par
+        ON o.property_id = par.property_id
+    LEFT JOIN latest_assessments AS la
+        ON o.property_id = la.property_id
+    LEFT JOIN `derived.current_assessments` AS ca
+        ON o.property_id = ca.property_id
+    WHERE o.category_code_description = 'RESIDENTIAL'
+        AND par.geometry IS NOT NULL
+);

--- a/tasks/export-property-tile-info/derived_property_tile_info.sql
+++ b/tasks/export-property-tile-info/derived_property_tile_info.sql
@@ -14,15 +14,13 @@ CREATE OR REPLACE TABLE `derived.property_tile_info` AS (
         o.property_id,
         o.location AS address,
         par.geometry AS geog,
-        ca.assessed_value AS current_assessed_value,
+        NULL AS current_assessed_value,
         la.tax_year_assessed_value
     FROM `core.opa_properties` AS o
     JOIN `core.pwd_parcels` AS par
         ON o.property_id = par.property_id
     LEFT JOIN latest_assessments AS la
         ON o.property_id = la.property_id
-    LEFT JOIN `derived.current_assessments` AS ca
-        ON o.property_id = ca.property_id
     WHERE o.category_code_description = 'RESIDENTIAL'
         AND par.geometry IS NOT NULL
 );

--- a/tasks/export-property-tile-info/derived_property_tile_info.sql
+++ b/tasks/export-property-tile-info/derived_property_tile_info.sql
@@ -3,6 +3,7 @@ CREATE OR REPLACE TABLE `derived.property_tile_info` AS (
         SELECT MAX(tax_year) AS max_year
         FROM `core.opa_assessments`
     ),
+
     latest_assessments AS (
         SELECT
             property_id,
@@ -10,6 +11,7 @@ CREATE OR REPLACE TABLE `derived.property_tile_info` AS (
         FROM `core.opa_assessments`
         WHERE tax_year = (SELECT max_year FROM latest_tax_year)
     )
+
     SELECT
         o.property_id,
         o.location AS address,
@@ -21,6 +23,7 @@ CREATE OR REPLACE TABLE `derived.property_tile_info` AS (
         ON o.property_id = par.property_id
     LEFT JOIN latest_assessments AS la
         ON o.property_id = la.property_id
-    WHERE o.category_code_description = 'RESIDENTIAL'
+    WHERE
+        o.category_code_description = 'RESIDENTIAL'
         AND par.geometry IS NOT NULL
 );

--- a/tasks/export-property-tile-info/main.py
+++ b/tasks/export-property-tile-info/main.py
@@ -1,0 +1,61 @@
+import json
+import os
+import functions_framework
+from google.cloud import bigquery, storage
+
+
+@functions_framework.http
+def export_property_tile_info(request):
+    """
+    HTTP-triggered Cloud Function: builds derived.property_tile_info in BigQuery,
+    then streams the result as a GeoJSON FeatureCollection to GCS temp bucket.
+    """
+    bq = bigquery.Client()
+    gcs = storage.Client()
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    # Step 1: Build derived.property_tile_info in BigQuery
+    sql_path = os.path.join(dir_path, 'derived_property_tile_info.sql')
+    with open(sql_path) as f:
+        sql = f.read()
+    print("Creating derived.property_tile_info...")
+    bq.query(sql).result()
+    print("derived.property_tile_info created.")
+
+    # Step 2: Export to GeoJSON and stream to GCS
+    export_sql = """
+        SELECT
+            property_id,
+            address,
+            ST_ASGEOJSON(geog) AS geom,
+            current_assessed_value,
+            tax_year_assessed_value
+        FROM `derived.property_tile_info`
+    """
+    bucket = gcs.bucket("musa5090s26-team6-temp_data")
+    blob = bucket.blob("property_tile_info.geojson")
+
+    print("Exporting GeoJSON to GCS...")
+    rows = bq.query(export_sql).result()
+    with blob.open("w") as f:
+        f.write('{"type":"FeatureCollection","features":[\n')
+        first = True
+        for row in rows:
+            feature = {
+                "type": "Feature",
+                "geometry": json.loads(row.geom),
+                "properties": {
+                    "property_id": row.property_id,
+                    "address": row.address,
+                    "current_assessed_value": row.current_assessed_value,
+                    "tax_year_assessed_value": row.tax_year_assessed_value,
+                },
+            }
+            if not first:
+                f.write(",\n")
+            f.write(json.dumps(feature))
+            first = False
+        f.write("\n]}")
+
+    print("Done. GeoJSON uploaded to gs://musa5090s26-team6-temp_data/property_tile_info.geojson")
+    return "Success", 200

--- a/tasks/export-property-tile-info/requirements.txt
+++ b/tasks/export-property-tile-info/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.4.0
+google-cloud-bigquery==3.11.4
+google-cloud-storage==2.10.0

--- a/tasks/generate-property-map-tiles/Containerfile
+++ b/tasks/generate-property-map-tiles/Containerfile
@@ -1,0 +1,9 @@
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+
+RUN apt-get update && apt-get install -y gdal-bin && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY script.sh .
+RUN chmod +x script.sh
+
+ENTRYPOINT ["/app/script.sh"]

--- a/tasks/generate-property-map-tiles/Dockerfile
+++ b/tasks/generate-property-map-tiles/Dockerfile
@@ -1,0 +1,9 @@
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim
+
+RUN apt-get update && apt-get install -y gdal-bin && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY script.sh .
+RUN chmod +x script.sh
+
+ENTRYPOINT ["/app/script.sh"]

--- a/tasks/generate-property-map-tiles/script.sh
+++ b/tasks/generate-property-map-tiles/script.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEMP_BUCKET="musa5090s26-team6-temp_data"
+PUBLIC_BUCKET="musa5090s26-team6-public"
+GEOJSON_PATH="/tmp/property_tile_info.geojson"
+TILES_DIR="/tmp/tiles"
+
+echo "Step 1: Downloading property_tile_info.geojson from GCS..."
+gcloud storage cp "gs://${TEMP_BUCKET}/property_tile_info.geojson" "${GEOJSON_PATH}"
+
+echo "Step 2: Converting to Mapbox Vector Tiles (zoom 12-18)..."
+mkdir -p "${TILES_DIR}"
+ogr2ogr \
+  -f MVT "${TILES_DIR}" \
+  "${GEOJSON_PATH}" \
+  -dsco MINZOOM=12 \
+  -dsco MAXZOOM=18 \
+  -dsco COMPRESS=NO
+
+echo "Step 3: Uploading tiles to public GCS bucket..."
+gcloud storage cp -r "${TILES_DIR}/*" "gs://${PUBLIC_BUCKET}/tiles/"
+
+echo "Done. Tiles uploaded to gs://${PUBLIC_BUCKET}/tiles/"

--- a/tasks/transform-tax-year-assessment-bins/main.py
+++ b/tasks/transform-tax-year-assessment-bins/main.py
@@ -1,0 +1,26 @@
+import os
+import functions_framework
+from google.cloud import bigquery
+
+
+@functions_framework.http
+def transform_tax_year_assessment_bins(request):
+    """
+    HTTP-triggered Cloud Function: builds derived.tax_year_assessment_bins
+    in BigQuery by binning historical assessment values by tax year.
+    """
+    bq = bigquery.Client()
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+
+    sql_path = os.path.join(
+        dir_path,
+        'transform_tax_year_assessment_bins.sql',
+    )
+    with open(sql_path) as f:
+        sql = f.read()
+
+    print("Creating derived.tax_year_assessment_bins...")
+    bq.query(sql).result()
+    print("derived.tax_year_assessment_bins created.")
+
+    return "Success", 200

--- a/tasks/transform-tax-year-assessment-bins/requirements.txt
+++ b/tasks/transform-tax-year-assessment-bins/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.4.0
+google-cloud-bigquery==3.11.4

--- a/tasks/transform-tax-year-assessment-bins/transform_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/transform_tax_year_assessment_bins.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE TABLE `derived.tax_year_assessment_bins` AS (
+    WITH bins AS (
+        SELECT
+            tax_year,
+            FLOOR(assessed_value / 50000) * 50000 AS lower_bound,
+            FLOOR(assessed_value / 50000) * 50000 + 50000 AS upper_bound
+        FROM `core.opa_assessments`
+        WHERE assessed_value IS NOT NULL
+            AND assessed_value >= 0
+    )
+
+    SELECT
+        tax_year,
+        CAST(lower_bound AS INT64) AS lower_bound,
+        CAST(upper_bound AS INT64) AS upper_bound,
+        COUNT(*) AS property_count
+    FROM bins
+    GROUP BY
+        tax_year,
+        lower_bound,
+        upper_bound
+    ORDER BY
+        tax_year,
+        lower_bound
+);

--- a/tasks/transform-tax-year-assessment-bins/transform_tax_year_assessment_bins.sql
+++ b/tasks/transform-tax-year-assessment-bins/transform_tax_year_assessment_bins.sql
@@ -5,7 +5,8 @@ CREATE OR REPLACE TABLE `derived.tax_year_assessment_bins` AS (
             FLOOR(assessed_value / 50000) * 50000 AS lower_bound,
             FLOOR(assessed_value / 50000) * 50000 + 50000 AS upper_bound
         FROM `core.opa_assessments`
-        WHERE assessed_value IS NOT NULL
+        WHERE
+            assessed_value IS NOT NULL
             AND assessed_value >= 0
     )
 


### PR DESCRIPTION
# Description

Implements two Cloud tasks to support the assessment review map:

1. **`export-property-tile-info`** (Cloud Function) — joins `core.opa_properties`, `core.opa_assessments`, and `core.pwd_parcels` to build `derived.property_tile_info` in BigQuery, then streams it as a GeoJSON FeatureCollection to the temp bucket.

2. **`generate-property-map-tiles`** (Cloud Run job) — downloads the GeoJSON from the temp bucket, converts it to Mapbox Vector Tiles (zoom 12–18) using `ogr2ogr`, and uploads the `.pbf` files to the public bucket.

Both steps are integrated into the data pipeline workflow.

Resolves #24, Resolves #6

## Type of change

- [x] New feature

## What should the reviewer know?

`current_assessed_value` in `derived_property_tile_info.sql` is intentionally `NULL` — it is a placeholder until the prediction model populates `derived.current_assessments`.

## Post-merge follow-ups

- [x] Actions required (specified below)

Deploy the Cloud Function:
```bash
gcloud functions deploy export-property-tile-info \
  --runtime python311 --trigger-http --region us-east4
