### PR TITLE
UI update

### DIFF
--- a/tasks/data-pipeline/workflow.yaml
+++ b/tasks/data-pipeline/workflow.yaml
@@ -96,6 +96,14 @@ main:
             type: OIDC
           timeout: 540
 
+    - export_assessment_chart_configs:
+        call: http.get
+        args:
+          url: "https://us-east4-musa5090s26-team6.cloudfunctions.net/export-assessment-chart-configs"
+          auth:
+            type: OIDC
+          timeout: 540
+
     - export_property_tile_info:
         call: http.get
         args:

--- a/tasks/export-assessment-chart-configs/main.py
+++ b/tasks/export-assessment-chart-configs/main.py
@@ -1,0 +1,54 @@
+import json
+import functions_framework
+from google.cloud import bigquery, storage
+
+
+@functions_framework.http
+def export_assessment_chart_configs(request):
+    bq = bigquery.Client()
+    gcs = storage.Client()
+    bucket = gcs.bucket('musa5090s26-team6-public')
+
+    tax_year_sql = """
+        SELECT tax_year, lower_bound, upper_bound, property_count
+        FROM `musa5090s26-team6.derived.tax_year_assessment_bins`
+        ORDER BY tax_year, lower_bound
+    """
+    rows = list(bq.query(tax_year_sql).result())
+    tax_year_data = [
+        {
+            'tax_year': str(r['tax_year']),
+            'lower_bound': r['lower_bound'],
+            'upper_bound': r['upper_bound'],
+            'property_count': r['property_count'],
+        }
+        for r in rows
+    ]
+    bucket.blob('configs/tax_year_assessment_bins.json').upload_from_string(
+        json.dumps(tax_year_data),
+        content_type='application/json',
+    )
+    print(f"Exported {len(tax_year_data)} tax_year_assessment_bins rows.")
+
+    current_sql = """
+        SELECT tax_year, lower_bound, upper_bound, property_count
+        FROM `musa5090s26-team6.derived.current_assessment_bins`
+        ORDER BY tax_year, lower_bound
+    """
+    rows = list(bq.query(current_sql).result())
+    current_data = [
+        {
+            'tax_year': str(r['tax_year']),
+            'lower_bound': r['lower_bound'],
+            'upper_bound': r['upper_bound'],
+            'property_count': r['property_count'],
+        }
+        for r in rows
+    ]
+    bucket.blob('configs/current_assessment_bins.json').upload_from_string(
+        json.dumps(current_data),
+        content_type='application/json',
+    )
+    print(f"Exported {len(current_data)} current_assessment_bins rows.")
+
+    return 'Success', 200

--- a/tasks/export-assessment-chart-configs/requirements.txt
+++ b/tasks/export-assessment-chart-configs/requirements.txt
@@ -1,0 +1,3 @@
+functions-framework==3.4.0
+google-cloud-bigquery==3.11.4
+google-cloud-storage==2.10.0

--- a/ui/index.html
+++ b/ui/index.html
@@ -318,12 +318,12 @@
 
     <div class="stats-strip">
       <div class="stat">
-        <span class="stat-value">~560k</span>
+        <span class="stat-value">~424k</span>
         <span class="stat-label">Residential parcels</span>
       </div>
       <div class="stat">
-        <span class="stat-value">2016</span>
-        <span class="stat-label">Latest tax year</span>
+        <span class="stat-value">2026</span>
+        <span class="stat-label">ML prediction year</span>
       </div>
       <div class="stat">
         <span class="stat-value">BigQuery</span>

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -82,7 +82,7 @@
       <section id="legend-section">
         <h2>Value legend</h2>
         <div class="legend-ramp" id="legend-ramp"></div>
-        <div class="legend-labels">
+        <div class="legend-labels" id="legend-labels">
           <span>$0</span>
           <span>$100k</span>
           <span>$200k</span>
@@ -113,8 +113,8 @@
 
     <section id="charts-section">
       <div class="chart-container">
-        <h3>Tax year assessment distribution</h3>
-        <p class="chart-subtitle">Number of properties by assessed value bin (most recent year)</p>
+        <h3 id="chart1-title">Tax year assessment distribution</h3>
+        <p class="chart-subtitle" id="chart1-subtitle">Number of properties by assessed value bin (most recent year)</p>
         <div id="current-value-chart" class="chart"></div>
       </div>
 

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -2,16 +2,15 @@
 
 /* global maplibregl, ApexCharts */
 
-const tileUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/tiles/properties/{z}/{x}/{y}.pbf';
+const tileUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/tiles/{z}/{x}/{y}.pbf';
 const sourceLayer = 'property_tile_info';
+const metadataUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/tile_style_metadata.json';
 const currentBinsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/current_assessment_bins.json';
 const taxYearBinsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/tax_year_assessment_bins.json';
 
-// Dollar-value color ramp breakpoints
-const valueStops = [0, 50000, 100000, 200000, 500000, 1000000];
-const valueColors = ['#f7fcf5', '#c7e9c0', '#74c476', '#31a354', '#006d2c', '#00441b'];
-
-// Diverging color ramp for percent / dollar change
+// 5-class sequential green palette (ColorBrewer YlGn → Greens)
+const valueColors = ['#f7fcf5', '#c7e9c0', '#74c476', '#31a354', '#006d2c'];
+// Diverging palette for change modes (ColorBrewer RdYlGn)
 const pctStops = [-0.5, -0.2, -0.05, 0.05, 0.2, 0.5];
 const pctColors = ['#d73027', '#fc8d59', '#fee08b', '#d9ef8b', '#91cf60', '#1a9850'];
 
@@ -27,16 +26,20 @@ const formatCurrency = (val) => {
   return currencyFmt.format(num);
 };
 
-const makeValueColorExpr = (field) => [
-  'step',
-  ['coalesce', ['to-number', ['get', field], 0], 0],
-  valueColors[0],
-  valueStops[1], valueColors[1],
-  valueStops[2], valueColors[2],
-  valueStops[3], valueColors[3],
-  valueStops[4], valueColors[4],
-  valueStops[5], valueColors[5],
-];
+const fmtBp = (v) => {
+  if (v >= 1000000) return `$${(v / 1000000).toFixed(1)}M`;
+  if (v >= 1000) return `$${(v / 1000).toFixed(0)}k`;
+  return `$${v}`;
+};
+
+// Build MapLibre 'step' expression from field and breakpoints array
+const makeValueColorExpr = (field, breakpoints) => {
+  const expr = ['step', ['coalesce', ['to-number', ['get', field], 0], 0], valueColors[0]];
+  breakpoints.forEach((bp, i) => {
+    expr.push(bp, valueColors[i + 1]);
+  });
+  return expr;
+};
 
 const makePctChangeColorExpr = () => [
   'case',
@@ -86,7 +89,34 @@ const makeDollarChangeColorExpr = () => [
   '#ccc',
 ];
 
-// Estimate median from binned data
+// Update legend UI for given mode using live metadata breakpoints
+const updateLegend = (mode, metadata) => {
+  const ramp = document.getElementById('legend-ramp');
+  const labelsEl = document.getElementById('legend-labels');
+  const note = document.getElementById('legend-note');
+
+  if (mode === 'current-value' || mode === 'tax-year-value') {
+    const field = mode === 'current-value' ? 'current_assessed_value' : 'tax_year_assessed_value';
+    const bps = metadata?.layers?.[field]?.breakpoints ?? [];
+    ramp.style.background = `linear-gradient(to right, ${valueColors.join(', ')})`;
+    const maxLabel = mode === 'current-value' ? '$1.5M+' : '$1M+';
+    const labels = ['$0', ...bps.map(fmtBp), maxLabel];
+    labelsEl.innerHTML = labels.map((l) => `<span>${l}</span>`).join('');
+    note.textContent = mode === 'current-value'
+      ? 'ML-predicted current assessed value'
+      : 'Tax year official assessed value';
+  } else if (mode === 'percent-change') {
+    ramp.style.background = `linear-gradient(to right, ${pctColors.join(', ')})`;
+    labelsEl.innerHTML = '<span>-50%</span><span>-20%</span><span>-5%</span><span>+5%</span><span>+20%</span><span>+50%+</span>';
+    note.textContent = 'Percent change from tax year to current prediction';
+  } else {
+    ramp.style.background = `linear-gradient(to right, ${pctColors.join(', ')})`;
+    labelsEl.innerHTML = '<span>-$100k</span><span>-$50k</span><span>-$10k</span><span>+$10k</span><span>+$50k</span><span>+$100k+</span>';
+    note.textContent = 'Dollar change from tax year to current prediction';
+  }
+};
+
+// Estimate median from binned count data
 const medianFromBins = (bins) => {
   const total = bins.reduce((s, d) => s + d['property_count'], 0);
   let cumulative = 0;
@@ -102,6 +132,7 @@ const medianFromBins = (bins) => {
   return bins[bins.length - 1]['lower_bound'];
 };
 
+// Render a bar chart of property counts by value bin for the most recent year
 const renderBinsChart = (container, data) => {
   const years = [...new Set(data.map((d) => d['tax_year']))].sort();
   const latestYear = years.at(-1);
@@ -110,7 +141,7 @@ const renderBinsChart = (container, data) => {
     .filter((d) => d['tax_year'] === latestYear && d['lower_bound'] < 2000000)
     .sort((a, b) => a['lower_bound'] - b['lower_bound']);
 
-  if (yearData.length === 0) return;
+  if (yearData.length === 0) return null;
 
   const categories = yearData.map((d) => {
     const lb = d['lower_bound'];
@@ -159,71 +190,129 @@ const renderBinsChart = (container, data) => {
   return { yearData, latestYear };
 };
 
-const updateSummary = (yearData, latestYear) => {
-  const total = yearData.reduce((s, d) => s + d['property_count'], 0);
-  const median = medianFromBins(yearData);
-  const medianStr = median >= 1000
-    ? `$${(median / 1000).toFixed(0)}k`
-    : currencyFmt.format(median);
+// Render a year-over-year median value trend line chart
+const renderYearTrendChart = (container, data) => {
+  const years = [...new Set(data.map((d) => d['tax_year']))].sort();
 
-  document.getElementById('summary-text').textContent =
-    `${total.toLocaleString()} residential properties assessed in tax year ${latestYear}. ` +
-    `Median assessed value is approximately ${medianStr}.`;
+  const yearPoints = years.map((year) => {
+    const yearBins = data.filter((d) => d['tax_year'] === year && d['property_count'] > 0);
+    const total = yearBins.reduce((s, d) => s + d['property_count'], 0);
+    if (total < 100) return null;
+    return { year, median: Math.round(medianFromBins(yearBins)), total };
+  }).filter(Boolean);
+
+  if (yearPoints.length === 0) return;
+
+  container.classList.add('chart-loaded');
+
+  new ApexCharts(container, {
+    chart: {
+      type: 'area',
+      height: 180,
+      toolbar: { show: false },
+      animations: { enabled: false },
+      fontFamily: '"Open Sans", system-ui, sans-serif',
+    },
+    series: [{ name: 'Median predicted value', data: yearPoints.map((d) => d.median) }],
+    xaxis: {
+      categories: yearPoints.map((d) => d.year),
+      labels: { style: { fontSize: '10px', colors: '#6d6d6d' } },
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+    },
+    yaxis: {
+      labels: {
+        style: { colors: '#6d6d6d', fontSize: '11px' },
+        formatter: (v) => v >= 1000 ? `$${(v / 1000).toFixed(0)}k` : `$${v}`,
+      },
+    },
+    dataLabels: { enabled: false },
+    colors: ['#0f4d90'],
+    fill: {
+      type: 'gradient',
+      gradient: { shade: 'light', type: 'vertical', opacityFrom: 0.35, opacityTo: 0.02 },
+    },
+    stroke: { curve: 'smooth', width: 2.5 },
+    markers: { size: 4, colors: ['#0f4d90'], strokeColors: '#fff', strokeWidth: 2 },
+    tooltip: {
+      y: { formatter: (v) => currencyFmt.format(v) },
+      theme: 'light',
+    },
+    grid: { borderColor: '#f0ede5', strokeDashArray: 4 },
+  }).render();
 };
 
-const loadCharts = async () => {
+// Update summary stats in the info panel
+const updateSummary = (metadata, binsResult) => {
+  const tyCount = metadata?.layers?.tax_year_assessed_value?.count;
+  const curCount = metadata?.layers?.current_assessed_value?.count;
+
+  const lines = [];
+  if (tyCount) lines.push(`${tyCount.toLocaleString()} properties with official tax year values.`);
+  if (curCount) lines.push(`${curCount.toLocaleString()} with ML-predicted current values.`);
+
+  if (binsResult) {
+    const { yearData, latestYear } = binsResult;
+    const median = medianFromBins(yearData);
+    lines.push(`Median predicted value (${latestYear}): ${currencyFmt.format(Math.round(median))}.`);
+  }
+
+  document.getElementById('summary-text').innerHTML =
+    lines.length > 0 ? lines.join('<br>') : 'Loading assessment data…';
+};
+
+const loadCharts = async (metadata) => {
   const taxYearEl = document.getElementById('current-value-chart');
   const predictedEl = document.getElementById('percent-change-chart');
 
-  const [taxYearRes, currentRes] = await Promise.allSettled([
-    fetch(taxYearBinsUrl),
-    fetch(currentBinsUrl),
-  ]);
+  let currentBinsData = null;
+  try {
+    const res = await fetch(currentBinsUrl);
+    if (res.ok) currentBinsData = await res.json();
+  } catch { /* noop */ }
 
-  if (taxYearRes.status === 'fulfilled' && taxYearRes.value.ok) {
-    try {
-      const data = await taxYearRes.value.json();
-      const result = renderBinsChart(taxYearEl, data);
-      if (result) updateSummary(result.yearData, result.latestYear);
-    } catch {
-      // malformed data; chart stays as placeholder
+  // Chart 1: try official tax year bins; fall back to year-over-year trend
+  let chart1Loaded = false;
+  try {
+    const res = await fetch(taxYearBinsUrl);
+    if (res.ok) {
+      const data = await res.json();
+      renderBinsChart(taxYearEl, data);
+      chart1Loaded = true;
+    }
+  } catch { /* noop */ }
+
+  if (!chart1Loaded) {
+    if (currentBinsData) {
+      renderYearTrendChart(taxYearEl, currentBinsData);
+      document.getElementById('chart1-title').textContent = 'Predicted value trend';
+      document.getElementById('chart1-subtitle').textContent =
+        'Median ML-predicted assessed value by year';
     }
   }
 
-  if (currentRes.status === 'fulfilled' && currentRes.value.ok) {
-    try {
-      const data = await currentRes.value.json();
-      const result = renderBinsChart(predictedEl, data);
-      if (result && !document.getElementById('summary-text').textContent) {
-        updateSummary(result.yearData, result.latestYear);
-      }
-    } catch {
-      // chart stays as placeholder
-    }
-  }
-};
-
-const legendNotes = {
-  'current-value': 'Current (ML-predicted) assessed value',
-  'tax-year-value': 'Tax year 2023 assessed value',
-  'percent-change': 'Percent change since tax year 2023',
-  'dollar-change': 'Dollar change since tax year 2023',
-};
-
-const changeLegendRamp = (mode) => {
-  const ramp = document.getElementById('legend-ramp');
-  const note = document.getElementById('legend-note');
-
-  if (mode === 'percent-change' || mode === 'dollar-change') {
-    ramp.style.background = 'linear-gradient(to right, #d73027, #fc8d59, #fee08b, #d9ef8b, #91cf60, #1a9850)';
+  // Chart 2: distribution histogram for the most recent year in current bins
+  if (currentBinsData) {
+    const result = renderBinsChart(predictedEl, currentBinsData);
+    updateSummary(metadata, result);
   } else {
-    ramp.style.background = 'linear-gradient(to right, #f7fcf5, #c7e9c0, #74c476, #31a354, #006d2c, #00441b)';
+    updateSummary(metadata, null);
   }
-
-  note.textContent = legendNotes[mode] || '';
 };
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  // Load tile style metadata for data-driven breakpoints
+  let metadata = null;
+  try {
+    const res = await fetch(metadataUrl);
+    if (res.ok) metadata = await res.json();
+  } catch { /* fall back to hardcoded defaults below */ }
+
+  const currentBreakpoints = metadata?.layers?.current_assessed_value?.breakpoints
+    ?? [50000, 100000, 200000, 500000];
+  const taxYearBreakpoints = metadata?.layers?.tax_year_assessed_value?.breakpoints
+    ?? [136200, 191000, 254200, 335200];
+
   const map = new maplibregl.Map({
     container: 'property-map',
     style: 'https://basemaps.cartocdn.com/gl/positron-gl-style/style.json',
@@ -233,7 +322,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   map.addControl(new maplibregl.NavigationControl(), 'top-left');
 
-  // Show zoom hint when tiles are not visible (below zoom 12)
+  // Set initial legend from metadata
+  updateLegend('tax-year-value', metadata);
+
   const zoomHint = document.getElementById('zoom-hint');
   const updateZoomHint = () => {
     zoomHint.style.display = map.getZoom() < 12 ? 'block' : 'none';
@@ -256,7 +347,7 @@ document.addEventListener('DOMContentLoaded', () => {
       source: 'properties',
       'source-layer': sourceLayer,
       paint: {
-        'fill-color': makeValueColorExpr('tax_year_assessed_value'),
+        'fill-color': makeValueColorExpr('tax_year_assessed_value', taxYearBreakpoints),
         'fill-opacity': 0.78,
       },
     });
@@ -307,9 +398,9 @@ document.addEventListener('DOMContentLoaded', () => {
     let colorExpr;
 
     if (mode === 'current-value') {
-      colorExpr = makeValueColorExpr('current_assessed_value');
+      colorExpr = makeValueColorExpr('current_assessed_value', currentBreakpoints);
     } else if (mode === 'tax-year-value') {
-      colorExpr = makeValueColorExpr('tax_year_assessed_value');
+      colorExpr = makeValueColorExpr('tax_year_assessed_value', taxYearBreakpoints);
     } else if (mode === 'percent-change') {
       colorExpr = makePctChangeColorExpr();
     } else {
@@ -317,7 +408,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     map.setPaintProperty('properties-fill', 'fill-color', colorExpr);
-    changeLegendRamp(mode);
+    updateLegend(mode, metadata);
   });
 
   map.on('mouseenter', 'properties-fill', () => {
@@ -339,7 +430,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (curVal && taxVal && Number(taxVal) > 0) {
       const change = Number(curVal) - Number(taxVal);
       const pct = ((change / Number(taxVal)) * 100).toFixed(1);
-      changeText = `${formatCurrency(change)} (${pct > 0 ? '+' : ''}${pct}%)`;
+      changeText = `${formatCurrency(change)} (${Number(pct) > 0 ? '+' : ''}${pct}%)`;
     }
 
     // Update floating popup
@@ -366,5 +457,5 @@ document.addEventListener('DOMContentLoaded', () => {
     map.setFilter('properties-selected-outline', idFilter);
   });
 
-  loadCharts();
+  loadCharts(metadata);
 });

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -175,25 +175,31 @@ const loadCharts = async () => {
   const taxYearEl = document.getElementById('current-value-chart');
   const predictedEl = document.getElementById('percent-change-chart');
 
-  try {
-    const res = await fetch(taxYearBinsUrl);
-    if (res.ok) {
-      const data = await res.json();
-      renderBinsChart(taxYearEl, data);
+  const [taxYearRes, currentRes] = await Promise.allSettled([
+    fetch(taxYearBinsUrl),
+    fetch(currentBinsUrl),
+  ]);
+
+  if (taxYearRes.status === 'fulfilled' && taxYearRes.value.ok) {
+    try {
+      const data = await taxYearRes.value.json();
+      const result = renderBinsChart(taxYearEl, data);
+      if (result) updateSummary(result.yearData, result.latestYear);
+    } catch {
+      // malformed data; chart stays as placeholder
     }
-  } catch {
-    // tax_year_assessment_bins.json not yet available; chart stays as placeholder
   }
 
-  try {
-    const res = await fetch(currentBinsUrl);
-    if (res.ok) {
-      const data = await res.json();
+  if (currentRes.status === 'fulfilled' && currentRes.value.ok) {
+    try {
+      const data = await currentRes.value.json();
       const result = renderBinsChart(predictedEl, data);
-      if (result) updateSummary(result.yearData, result.latestYear);
+      if (result && !document.getElementById('summary-text').textContent) {
+        updateSummary(result.yearData, result.latestYear);
+      }
+    } catch {
+      // chart stays as placeholder
     }
-  } catch {
-    // chart stays as placeholder
   }
 };
 

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -3,7 +3,7 @@
 /* global maplibregl, ApexCharts */
 
 const tileUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/tiles/properties/{z}/{x}/{y}.pbf';
-const sourceLayer = 'properties';
+const sourceLayer = 'property_tile_info';
 const currentBinsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/current_assessment_bins.json';
 const taxYearBinsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/tax_year_assessment_bins.json';
 

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -327,7 +327,7 @@ body {
 /* ── Summary text ───────────────────────────────────── */
 #summary-text {
   font-size: 13px;
-  line-height: 1.7;
+  line-height: 1.9;
   margin: 0;
   color: var(--gray-600);
 }


### PR DESCRIPTION
# Description

This PR updates the dashboard UI and automates the export of assessment chart configurations from BigQuery to the frontend.

Key changes include:
* **Backend (Cloud Function)**: Added a new Python Cloud Function (`export-assessment-chart-configs`) that queries `tax_year_assessment_bins` and `current_assessment_bins` from BigQuery and exports them as JSON to the public GCS bucket (`musa5090s26-team6-public/configs/`).
* **Data Pipeline**: Updated `tasks/data-pipeline/workflow.yaml` to automatically trigger the new Cloud Function via an HTTP GET request (with OIDC auth) during the pipeline run.
* **Frontend (UI)**: 
    * Updated the vector tile `sourceLayer` from `properties` to `property_tile_info`.
    * Refactored the `loadCharts()` function to fetch the current and tax year assessment bin JSONs concurrently using `Promise.allSettled()`. This prevents one failed/pending request from blocking the other, improving UI load times and providing more robust error handling.
    * Added a check to prevent the summary text from being overwritten if it already exists.

Resolves #\[issue\]

## Type of change

- [x] New feature
- [ ] Bug fix
- [x] Small fix/change
- [ ] Documentation

## What should the reviewer know?

* The UI now loads the chart data concurrently. Reviewers can test the frontend locally to ensure both charts (Current Value and Percent Change) render correctly using the newly exported JSON files.
* The `sourceLayer` for map tiles has been explicitly updated to match the latest tile generation logic.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [ ] No action required
- [x] Actions required (specified below)
