### PR TITLE
Fix export-assessment-chart-configs and deploy to Cloud Run

### DIFF
--- a/tasks/export-assessment-chart-configs/main.py
+++ b/tasks/export-assessment-chart-configs/main.py
@@ -31,14 +31,13 @@ def export_assessment_chart_configs(request):
     print(f"Exported {len(tax_year_data)} tax_year_assessment_bins rows.")
 
     current_sql = """
-        SELECT tax_year, lower_bound, upper_bound, property_count
+        SELECT lower_bound, upper_bound, property_count
         FROM `musa5090s26-team6.derived.current_assessment_bins`
-        ORDER BY tax_year, lower_bound
+        ORDER BY lower_bound
     """
     rows = list(bq.query(current_sql).result())
     current_data = [
         {
-            'tax_year': str(r['tax_year']),
             'lower_bound': r['lower_bound'],
             'upper_bound': r['upper_bound'],
             'property_count': r['property_count'],

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -134,12 +134,21 @@ const medianFromBins = (bins) => {
 
 // Render a bar chart of property counts by value bin for the most recent year
 const renderBinsChart = (container, data) => {
-  const years = [...new Set(data.map((d) => d['tax_year']))].sort();
-  const latestYear = years.at(-1);
+  const hasTaxYear = data.length > 0 && 'tax_year' in data[0];
+  let yearData, latestYear;
 
-  const yearData = data
-    .filter((d) => d['tax_year'] === latestYear && d['lower_bound'] < 2000000)
-    .sort((a, b) => a['lower_bound'] - b['lower_bound']);
+  if (hasTaxYear) {
+    const years = [...new Set(data.map((d) => d['tax_year']))].sort();
+    latestYear = years.at(-1);
+    yearData = data
+      .filter((d) => d['tax_year'] === latestYear && d['lower_bound'] < 2000000)
+      .sort((a, b) => a['lower_bound'] - b['lower_bound']);
+  } else {
+    latestYear = null;
+    yearData = data
+      .filter((d) => d['lower_bound'] < 2000000)
+      .sort((a, b) => a['lower_bound'] - b['lower_bound']);
+  }
 
   if (yearData.length === 0) return null;
 
@@ -283,7 +292,8 @@ const loadCharts = async (metadata) => {
   } catch { /* noop */ }
 
   if (!chart1Loaded) {
-    if (currentBinsData) {
+    const hasTaxYear = currentBinsData?.length > 0 && 'tax_year' in currentBinsData[0];
+    if (currentBinsData && hasTaxYear) {
       renderYearTrendChart(taxYearEl, currentBinsData);
       document.getElementById('chart1-title').textContent = 'Predicted value trend';
       document.getElementById('chart1-subtitle').textContent =


### PR DESCRIPTION
# Description

Fixes the reviewer map (tiles were not rendering due to wrong URL and layer name), adds data-driven map legend from tile metadata, deploys the export-assessment-chart-configs Cloud Run function, and wires up both assessment distribution charts with real data.

Resolves #16, Resolves #18, Resolves #19

## Type of change

- [ ] New feature
- [x] Bug fix
- [x] Small fix/change
- [ ] Documentation

## What should the reviewer know?

Bug fixes (map was completely blank before):                                                                          
  - tileUrl had an extra /properties/ path segment that returned 404
  - sourceLayer was 'properties' but the actual layer name is 'property_tile_info' (confirmed from tiles/metadata.json) 
                                                                                                                       
  Data-driven legend:                                                                                                   
  - Loads tile_style_metadata.json at startup to get real data breakpoints                                              
  - Legend labels and color ramps update dynamically per map mode                                                       
                                                                                                                        
  Chart data:                                                                                                           
  - export-assessment-chart-configs deployed as a Cloud Run Function (us-east4)                                         
  - Fixed a bug in the function where current_assessment_bins query referenced a tax_year column that doesn't exist in  
  the table                                                                                                             
  - Both tax_year_assessment_bins.json and current_assessment_bins.json now export successfully

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [ ] No action required
- [x] Actions required (specified below)

Run the following to re-export chart config JSONs to GCS after merge:                                                 
   
  gcloud functions call export-assessment-chart-configs \                                                               
    --gen2 --region=us-east4 --project=musa5090s26-team6 
