### PR TITLE
add current_assessment to workflow

### DIFF
--- a/tasks/data-pipeline/workflow.yaml
+++ b/tasks/data-pipeline/workflow.yaml
@@ -79,6 +79,14 @@ main:
           auth:
             type: OIDC
           timeout: 540
+    
+    - predict_current_assessments:
+        call: http.get
+        args:
+          url: "https://us-east4-musa5090s26-team6.cloudfunctions.net/predict-current-assessments"
+          auth:
+            type: OIDC
+          timeout: 1800
 
     - export_property_tile_info:
         call: http.get


### PR DESCRIPTION
## Changes
- Deployed predict-current-assessments Cloud Function to GCP
- Added predict-current-assessments to data-pipeline workflow.yaml
- Cloud Function trains saleprice_model_current and predicts current assessment values for all residential properties
- Results stored in derived.current_assessments

## How it works
1. Triggered weekly via data-pipeline workflow
2. Retrains model using derived.current_assessments_model_training_data
3. Predicts sale price for all residential properties in core.opa_properties
4. Stores results in derived.current_assessments (property_id, predicted_value, predicted_at)