### PR TITLE
UI overhaul: reviewer map controls, widget property details, and dashboard redesig

### DIFF
--- a/tasks/export-property-tile-info/derived_property_tile_info.sql
+++ b/tasks/export-property-tile-info/derived_property_tile_info.sql
@@ -33,6 +33,7 @@ CREATE OR REPLACE TABLE `derived.property_tile_info` AS (
     SELECT
         o.property_id,
         o.location AS address,
+        o.zip_code,
         par.geometry AS geog,
         cp.predicted_value AS current_assessed_value,
         la.tax_year_assessed_value

--- a/tasks/generate-property-map-tiles/script.sh
+++ b/tasks/generate-property-map-tiles/script.sh
@@ -16,13 +16,16 @@ ogr2ogr \
   "${GEOJSON_PATH}" \
   -dsco MINZOOM=12 \
   -dsco MAXZOOM=18 \
-  -dsco COMPRESS=NO
+  -dsco COMPRESS=YES \
+  -dsco MAX_SIZE=2000000
 
 echo "Step 3: Uploading tiles to public GCS bucket..."
-# Upload under tiles/properties/ to match the frontend's URL template:
-#   https://storage.googleapis.com/<bucket>/tiles/properties/{z}/{x}/{y}.pbf
+# Tiles are gzip-compressed (.pbf); set content-type and content-encoding so
+# browsers and MapLibre can decompress them correctly.
 # Clean up any previous run first so stale tiles don't linger.
-gcloud storage rm -r "gs://${PUBLIC_BUCKET}/tiles/properties/" 2>/dev/null || true
-gcloud storage cp -r "${TILES_DIR}/*" "gs://${PUBLIC_BUCKET}/tiles/properties/"
+gcloud storage rm -r "gs://${PUBLIC_BUCKET}/tiles/" 2>/dev/null || true
+gcloud storage cp -r "${TILES_DIR}/*" "gs://${PUBLIC_BUCKET}/tiles/" \
+  --content-type="application/vnd.mapbox-vector-tile" \
+  --content-encoding="gzip"
 
-echo "Done. Tiles uploaded to gs://${PUBLIC_BUCKET}/tiles/properties/"
+echo "Done. Tiles uploaded to gs://${PUBLIC_BUCKET}/tiles/"

--- a/tasks/property-lookup/main.py
+++ b/tasks/property-lookup/main.py
@@ -1,0 +1,100 @@
+import json
+import functions_framework
+from google.cloud import bigquery
+
+PROJECT = 'musa5090s26-team6'
+DATASET = 'core'
+
+CORS_HEADERS = {
+    'Access-Control-Allow-Origin': '*',
+    'Content-Type': 'application/json',
+}
+
+
+def _ok(data):
+    return (json.dumps(data, default=str), 200, CORS_HEADERS)
+
+
+def _err(msg, status=400):
+    return (json.dumps({'error': msg}), status, CORS_HEADERS)
+
+
+@functions_framework.http
+def property_lookup(request):
+    if request.method == 'OPTIONS':
+        return ('', 204, {
+            'Access-Control-Allow-Origin': '*',
+            'Access-Control-Allow-Methods': 'GET',
+            'Access-Control-Allow-Headers': 'Content-Type',
+        })
+
+    bq = bigquery.Client(project=PROJECT)
+
+    # ── Address search: ?search=1234+MARKET ──────────────
+    search = request.args.get('search', '').strip().upper()
+    if search:
+        sql = f"""
+            SELECT property_id, location, owner_1, market_value
+            FROM `{PROJECT}.{DATASET}.opa_properties`
+            WHERE UPPER(location) LIKE @prefix
+              AND category_code IN ('1', '2', '8', '13', '14')
+            ORDER BY location
+            LIMIT 5
+        """
+        cfg = bigquery.QueryJobConfig(query_parameters=[
+            bigquery.ScalarQueryParameter('prefix', 'STRING', search + '%'),
+        ])
+        rows = list(bq.query(sql, job_config=cfg).result())
+        return _ok([dict(r) for r in rows])
+
+    # ── Property + assessment history: ?parcel_number=xxx ─
+    parcel = request.args.get('parcel_number', '').strip()
+    if not parcel:
+        return _err('Provide ?search= or ?parcel_number=')
+
+    prop_sql = f"""
+        SELECT
+            property_id,
+            location,
+            owner_1,
+            market_value,
+            taxable_land,
+            taxable_building,
+            exempt_land,
+            exempt_building,
+            year_built,
+            number_of_bedrooms,
+            number_of_bathrooms,
+            total_livable_area,
+            category_code
+        FROM `{PROJECT}.{DATASET}.opa_properties`
+        WHERE property_id = @parcel
+        LIMIT 1
+    """
+    assess_sql = f"""
+        SELECT
+            year,
+            market_value,
+            taxable_land,
+            taxable_building,
+            exempt_land,
+            exempt_building
+        FROM `{PROJECT}.{DATASET}.opa_assessments`
+        WHERE property_id = @parcel
+        ORDER BY year ASC
+        LIMIT 50
+    """
+    cfg = bigquery.QueryJobConfig(query_parameters=[
+        bigquery.ScalarQueryParameter('parcel', 'STRING', parcel),
+    ])
+
+    prop_rows = list(bq.query(prop_sql, job_config=cfg).result())
+    if not prop_rows:
+        return _err('Property not found', 404)
+
+    assess_rows = list(bq.query(assess_sql, job_config=cfg).result())
+
+    return _ok({
+        'property': dict(prop_rows[0]),
+        'assessments': [dict(r) for r in assess_rows],
+    })

--- a/tasks/property-lookup/requirements.txt
+++ b/tasks/property-lookup/requirements.txt
@@ -1,0 +1,2 @@
+functions-framework==3.4.0
+google-cloud-bigquery==3.11.4

--- a/ui/index.html
+++ b/ui/index.html
@@ -66,38 +66,22 @@
       flex-direction: column;
       align-items: center;
       justify-content: center;
-      padding: 48px 24px;
-      gap: 52px;
+      padding: 20px 24px;
+      gap: 24px;
     }
 
     /* ── Hero ─────────────────────────────────────────── */
     .hero {
       text-align: center;
-      max-width: 600px;
-    }
-
-    .hero-eyebrow {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      background: rgb(255 255 255 / 12%);
-      border: 1px solid rgb(255 255 255 / 25%);
-      border-radius: 100px;
-      padding: 5px 18px;
-      font-size: 11px;
-      font-weight: 600;
-      letter-spacing: 0.8px;
-      text-transform: uppercase;
-      margin-bottom: 28px;
-      color: rgb(255 255 255 / 85%);
+      max-width: 560px;
     }
 
     .hero h1 {
       font-family: "Montserrat", system-ui, sans-serif;
-      font-size: clamp(28px, 5vw, 52px);
+      font-size: clamp(24px, 3.5vw, 40px);
       font-weight: 700;
       line-height: 1.12;
-      margin-bottom: 20px;
+      margin-bottom: 12px;
       letter-spacing: -0.5px;
     }
 
@@ -106,10 +90,10 @@
     }
 
     .hero-desc {
-      font-size: 16px;
-      line-height: 1.75;
+      font-size: 14px;
+      line-height: 1.7;
       color: rgb(255 255 255 / 72%);
-      max-width: 460px;
+      max-width: 440px;
       margin: 0 auto;
     }
 
@@ -120,6 +104,7 @@
       gap: 24px;
       width: 100%;
       max-width: 820px;
+      margin-top: 16px;
     }
 
     .card {
@@ -146,11 +131,11 @@
     }
 
     .card-inner {
-      padding: 32px 28px 28px;
+      padding: 22px 22px 18px;
       flex: 1;
       display: flex;
       flex-direction: column;
-      gap: 12px;
+      gap: 8px;
     }
 
     .card-icon {
@@ -206,7 +191,7 @@
     /* ── Stats strip ──────────────────────────────────── */
     .stats-strip {
       display: flex;
-      gap: 48px;
+      gap: 36px;
       flex-wrap: wrap;
       justify-content: center;
     }
@@ -217,18 +202,18 @@
 
     .stat-value {
       font-family: "Montserrat", system-ui, sans-serif;
-      font-size: 28px;
+      font-size: 22px;
       font-weight: 700;
       color: #f3c613;
       display: block;
     }
 
     .stat-label {
-      font-size: 12px;
+      font-size: 11px;
       color: rgb(255 255 255 / 60%);
       text-transform: uppercase;
       letter-spacing: 0.5px;
-      margin-top: 4px;
+      margin-top: 3px;
       display: block;
     }
 
@@ -263,11 +248,10 @@
   <main>
 
     <div class="hero">
-      <div class="hero-eyebrow">MUSA 5090 · Team 6 · Spring 2026</div>
       <h1>Philadelphia<br><span>CAMA</span> Dashboard</h1>
       <p class="hero-desc">
-        Computer-Assisted Mass Appraisal system for reviewing and analyzing
-        residential property assessments across Philadelphia.
+        Computer-Assisted Mass Appraisal platform for Philadelphia's
+        residential property assessment review and public lookup.
       </p>
     </div>
 
@@ -286,9 +270,9 @@
           </div>
           <h2>Tax Assessor Review</h2>
           <p>
-            Interactive map showing the most recent assessment values for every
-            residential parcel. Color-coded by value range, with distribution
-            charts and property detail lookup.
+            Compare ML-predicted values against official tax year assessments
+            on an interactive map. Filter by zip code, highlight large
+            discrepancies, and explore citywide distribution trends by year.
           </p>
           <span class="card-link">Open reviewer →</span>
         </div>
@@ -306,9 +290,9 @@
           </div>
           <h2>Property Owner Widget</h2>
           <p>
-            Look up the full assessment history for any residential property
-            by OPA ID. Charts and tables show market value trends across all
-            recorded tax years.
+            Search any Philadelphia address to view your property's full
+            assessment history — market value trends, year-over-year changes,
+            and a breakdown of taxable land versus building value.
           </p>
           <span class="card-link">Look up a property →</span>
         </div>
@@ -318,7 +302,7 @@
 
     <div class="stats-strip">
       <div class="stat">
-        <span class="stat-value">~424k</span>
+        <span class="stat-value" id="stat-total-props">~424k</span>
         <span class="stat-label">Residential parcels</span>
       </div>
       <div class="stat">
@@ -326,12 +310,12 @@
         <span class="stat-label">ML prediction year</span>
       </div>
       <div class="stat">
-        <span class="stat-value">BigQuery</span>
-        <span class="stat-label">Data pipeline</span>
+        <span class="stat-value" id="stat-median-value">—</span>
+        <span class="stat-label">Median assessed value</span>
       </div>
       <div class="stat">
-        <span class="stat-value">ML</span>
-        <span class="stat-label">Predicted values</span>
+        <span class="stat-value" id="stat-years-count">—</span>
+        <span class="stat-label">Years of OPA data</span>
       </div>
     </div>
 
@@ -339,8 +323,44 @@
 
   <footer>
     <span>© City of Philadelphia · Office of Property Assessment</span>
-    <span>MUSA 5090 Geospatial Cloud Computing · Team 6 · 2026</span>
+    <span>Philadelphia CAMA · Property Assessment Platform</span>
   </footer>
 
+  <script>
+    (async () => {
+      const binsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/tax_year_assessment_bins.json';
+      try {
+        const res = await fetch(binsUrl);
+        if (!res.ok) return;
+        const data = await res.json();
+
+        const years = [...new Set(data.map((d) => d['tax_year']))].sort();
+        const latestYear = years.at(-1);
+        const latestBins = data
+          .filter((d) => d['tax_year'] === latestYear && d['property_count'] > 0)
+          .sort((a, b) => a['lower_bound'] - b['lower_bound']);
+        const total = latestBins.reduce((s, d) => s + d['property_count'], 0);
+
+        let cumul = 0;
+        const half = total / 2;
+        let median = null;
+        for (const bin of latestBins) {
+          cumul += bin['property_count'];
+          if (cumul >= half) {
+            const frac = (cumul - half) / bin['property_count'];
+            median = bin['lower_bound'] + (bin['upper_bound'] - bin['lower_bound']) * (1 - frac);
+            break;
+          }
+        }
+
+        const fmtK = (n) => n >= 1000 ? `~${Math.round(n / 1000)}k` : String(n);
+        const fmtVal = (v) => v >= 1000000 ? `$${(v / 1000000).toFixed(1)}M` : `$${Math.round(v / 1000)}k`;
+
+        document.getElementById('stat-total-props').textContent = fmtK(total);
+        if (median !== null) document.getElementById('stat-median-value').textContent = fmtVal(Math.round(median));
+        document.getElementById('stat-years-count').textContent = String(years.length);
+      } catch { /* keep default placeholder values */ }
+    })();
+  </script>
 </body>
 </html>

--- a/ui/reviewer/index.html
+++ b/ui/reviewer/index.html
@@ -31,99 +31,171 @@
       </div>
       <h1>Tax Assessor Review</h1>
     </div>
-    <div id="header-controls"></div>
   </header>
 
   <main id="reviewer-main">
 
+    <!-- ── Map section ─────────────────────────────── -->
     <section id="map-section">
       <div id="property-map"></div>
 
-      <form id="map-layer-control">
-        <fieldset>
-          <legend>Map layer</legend>
+      <!-- Search panel: zip (top) + address (bottom, so dropdown goes down) -->
+      <div id="search-panel">
+        <div id="zip-filter">
+          <input type="text" id="zip-input" placeholder="Filter by zip code…" maxlength="5" inputmode="numeric">
+          <button id="zip-clear" hidden aria-label="Clear zip">×</button>
+          <button id="zip-browse-btn" aria-label="Browse all zip codes" title="Browse all zip codes">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="6 9 12 15 18 9"></polyline>
+            </svg>
+          </button>
+        </div>
+        <div id="address-search">
+          <input
+            type="text"
+            id="address-input"
+            placeholder="Search Philadelphia address…"
+            autocomplete="off"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded="false"
+            aria-controls="address-suggestions"
+          >
+          <button id="address-clear" hidden aria-label="Clear address">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+          <button id="address-search-btn" aria-label="Search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="11" cy="11" r="8"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+          </button>
+          <div id="address-suggestions" role="listbox" hidden></div>
+        </div>
+      </div>
 
-          <label>
-            <input type="radio" name="map-layer" value="current-value" checked>
-            <span>Current assessment</span>
+      <!-- Zip selector panel (opens when browse button clicked) -->
+      <div id="zip-selector" hidden>
+        <div class="zip-selector-header">
+          <span>Philadelphia zip codes</span>
+          <button id="zip-selector-close" aria-label="Close">×</button>
+        </div>
+        <div id="zip-list"></div>
+      </div>
+
+      <!-- Controls panel: map layer + discrepancy (top-right) -->
+      <div id="controls-panel">
+        <form id="map-layer-control">
+          <fieldset>
+            <legend>Map layer</legend>
+
+            <label>
+              <input type="radio" name="map-layer" value="current-value">
+              <span>ML predicted</span>
+            </label>
+
+            <label>
+              <input type="radio" name="map-layer" value="tax-year-value">
+              <span>Tax year value</span>
+            </label>
+
+            <label>
+              <input type="radio" name="map-layer" value="percent-change" checked>
+              <span>Change (%)</span>
+            </label>
+
+            <label>
+              <input type="radio" name="map-layer" value="dollar-change">
+              <span>Change ($)</span>
+            </label>
+          </fieldset>
+        </form>
+
+        <div id="discrepancy-filter">
+          <label class="filter-toggle-label">
+            <input type="checkbox" id="filter-toggle">
+            Highlight discrepancies
           </label>
+          <div id="filter-controls" hidden>
+            <div class="filter-row">
+              <span>Min change:</span>
+              <strong id="threshold-value">20%</strong>
+            </div>
+            <input type="range" id="threshold-slider" min="5" max="60" value="20" step="5">
+          </div>
+        </div>
+      </div>
 
-          <label>
-            <input type="radio" name="map-layer" value="tax-year-value">
-            <span>Tax year 2023</span>
-          </label>
-
-          <label>
-            <input type="radio" name="map-layer" value="percent-change">
-            <span>Change (%)</span>
-          </label>
-
-          <label>
-            <input type="radio" name="map-layer" value="dollar-change">
-            <span>Change ($)</span>
-          </label>
-        </fieldset>
-      </form>
-
-      <div id="property-popup" hidden>
-        <p class="popup-address">—</p>
-        <dl class="popup-details">
-          <dt>Current:</dt><dd>—</dd>
-          <dt>2023:</dt><dd>—</dd>
-          <dt>Change:</dt><dd>—</dd>
+      <!-- Hover tooltip (lightweight, follows cursor) -->
+      <div id="hover-tooltip" hidden>
+        <p class="tooltip-address">—</p>
+        <dl class="tooltip-dl">
+          <dt>ID</dt><dd id="tooltip-id">—</dd>
+          <dt id="tooltip-value-label">ML predicted</dt><dd id="tooltip-value">—</dd>
+          <dt id="tooltip-change-label" hidden>vs. tax year</dt><dd id="tooltip-change" hidden>—</dd>
         </dl>
+      </div>
+
+      <!-- Legend (bottom-right of map, vertical) -->
+      <div id="legend-box">
+        <p class="legend-note" id="legend-note">Tax year assessed value</p>
+        <div class="legend-body">
+          <div class="legend-ramp" id="legend-ramp"></div>
+          <div class="legend-labels" id="legend-labels">
+            <span>$1M+</span><span>$500k</span><span>$200k</span><span>$100k</span><span>$0</span>
+          </div>
+        </div>
       </div>
 
       <div id="zoom-hint" aria-live="polite">Zoom in to see individual properties</div>
     </section>
 
+    <!-- ── Info panel ──────────────────────────────── -->
     <aside id="info-panel">
 
-      <section id="legend-section">
-        <h2>Value legend</h2>
-        <div class="legend-ramp" id="legend-ramp"></div>
-        <div class="legend-labels" id="legend-labels">
-          <span>$0</span>
-          <span>$100k</span>
-          <span>$200k</span>
-          <span>$500k</span>
-          <span>$1M+</span>
-        </div>
-        <p class="legend-note" id="legend-note">Tax year assessed value</p>
-      </section>
-
+      <!-- Summary: OPA-focused comparison stats -->
       <section id="summary-section">
-        <h2>Summary</h2>
-        <p id="summary-text">Loading assessment data…</p>
+        <h2>Assessment Overview <span id="stat-selected-year" class="h2-year"></span></h2>
+        <div class="stat-cards">
+          <div class="stat-card">
+            <span class="stat-card-value" id="stat-coverage">—</span>
+            <span class="stat-card-label">Residential parcels</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card-value" id="stat-official-median">—</span>
+            <span class="stat-card-label">Official median (tax year)</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card-value" id="stat-predicted-median">—</span>
+            <span class="stat-card-label">ML predicted median</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-card-value" id="stat-ratio">—</span>
+            <span class="stat-card-label">Estimated market shift</span>
+          </div>
+        </div>
       </section>
 
-      <section id="selected-property">
-        <h2>Selected property</h2>
-        <p class="no-selection-hint" id="no-selection-hint">Click a property on the map to see details.</p>
-        <dl id="property-detail-list" hidden>
-          <dt>Address</dt><dd id="info-address">—</dd>
-          <dt>Property ID</dt><dd id="info-property-id">—</dd>
-          <dt>Current assessed value</dt><dd id="info-current-value">—</dd>
-          <dt>Tax year 2023 value</dt><dd id="info-tax-year-value">—</dd>
-          <dt>Change</dt><dd id="info-change">—</dd>
-        </dl>
+      <!-- Charts (moved from bottom) -->
+      <section id="charts-section">
+        <div class="chart-container">
+          <h3>Tax year distribution</h3>
+          <p class="chart-subtitle">Properties by assessed market value bin</p>
+          <div id="year-selector" class="year-selector"></div>
+          <div id="current-value-chart" class="chart"></div>
+        </div>
+
+        <div class="chart-container">
+          <h3>Predicted distribution</h3>
+          <p class="chart-subtitle">Properties by ML-predicted value bin</p>
+          <div id="percent-change-chart" class="chart"></div>
+        </div>
       </section>
 
     </aside>
-
-    <section id="charts-section">
-      <div class="chart-container">
-        <h3 id="chart1-title">Tax year assessment distribution</h3>
-        <p class="chart-subtitle" id="chart1-subtitle">Number of properties by assessed value bin (most recent year)</p>
-        <div id="current-value-chart" class="chart"></div>
-      </div>
-
-      <div class="chart-container">
-        <h3>Predicted assessment distribution</h3>
-        <p class="chart-subtitle">Number of properties by ML-predicted value bin (most recent year)</p>
-        <div id="percent-change-chart" class="chart"></div>
-      </div>
-    </section>
 
   </main>
 

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -204,54 +204,6 @@ const renderBinsChart = (container, data) => {
   return { yearData, latestYear };
 };
 
-// Render year-over-year median trend line chart
-const renderYearTrendChart = (container, data) => {
-  const years = [...new Set(data.map((d) => d['tax_year']))].sort();
-
-  const yearPoints = years.map((year) => {
-    const yearBins = data.filter((d) => d['tax_year'] === year && d['property_count'] > 0);
-    const total = yearBins.reduce((s, d) => s + d['property_count'], 0);
-    if (total < 100) return null;
-    return { year, median: Math.round(medianFromBins(yearBins)), total };
-  }).filter(Boolean);
-
-  if (yearPoints.length === 0) return;
-
-  container.classList.add('chart-loaded');
-
-  new ApexCharts(container, {
-    chart: {
-      type: 'area',
-      height: 150,
-      toolbar: { show: false },
-      animations: { enabled: false },
-      fontFamily: '"Open Sans", system-ui, sans-serif',
-    },
-    series: [{ name: 'Median predicted value', data: yearPoints.map((d) => d.median) }],
-    xaxis: {
-      categories: yearPoints.map((d) => d.year),
-      labels: { style: { fontSize: '9px', colors: '#6d6d6d' } },
-      axisBorder: { show: false },
-      axisTicks: { show: false },
-    },
-    yaxis: {
-      labels: {
-        style: { colors: '#6d6d6d', fontSize: '10px' },
-        formatter: (v) => v >= 1000 ? `$${(v / 1000).toFixed(0)}k` : `$${v}`,
-      },
-    },
-    dataLabels: { enabled: false },
-    colors: ['#0f4d90'],
-    fill: {
-      type: 'gradient',
-      gradient: { shade: 'light', type: 'vertical', opacityFrom: 0.35, opacityTo: 0.02 },
-    },
-    stroke: { curve: 'smooth', width: 2 },
-    markers: { size: 3, colors: ['#0f4d90'], strokeColors: '#fff', strokeWidth: 2 },
-    tooltip: { y: { formatter: (v) => currencyFmt.format(v) }, theme: 'light' },
-    grid: { borderColor: '#f0ede5', strokeDashArray: 4 },
-  }).render();
-};
 
 // Compute median + total for a given tax year from bins data
 const computeStatsForYear = (data, year) => {
@@ -453,6 +405,13 @@ const fetchSuggestions = async (query) => {
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
+  // Declare DOM refs early so they're available inside all closures below
+  const filterToggle = document.getElementById('filter-toggle');
+  const filterControls = document.getElementById('filter-controls');
+  const zipSelectorEl = document.getElementById('zip-selector');
+  // Assigned later once zip data is loaded; declared here to satisfy no-use-before-define
+  let loadAllZipBoundaries;
+
   // Load tile style metadata for data-driven breakpoints
   let metadata = null;
   try {
@@ -696,9 +655,6 @@ document.addEventListener('DOMContentLoaded', async () => {
     map.setFilter('properties-selected-outline', idFilter);
   });
 
-  // Shared reference needed by both popup and zip selector
-  const zipSelectorEl = document.getElementById('zip-selector');
-
   // Address autocomplete (Photon OSM, Philadelphia bounded)
   const addressInput = document.getElementById('address-input');
   const addressBtn = document.getElementById('address-search-btn');
@@ -819,7 +775,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         map.flyTo({ center: results[0].lngLat, zoom: 17 });
       } else {
         addressInput.style.outline = '2px solid #d73027';
-        setTimeout(() => { addressInput.style.outline = ''; }, 2000);
+        setTimeout(() => { addressInput.style.outline = '' }, 2000);
       }
     }
   });
@@ -938,13 +894,6 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   const clearHoveredZip = () => setHoveredZip(null);
 
-  const selectZip = (zip) => {
-    closeZipSelector();
-    zipInput.value = zip;
-    applyZip(zip);
-    showZipBoundary(zip);
-  };
-
   const openZipSelector = () => {
     zipSelectorEl.removeAttribute('hidden');
     ['zip-all-line', 'zip-hover-fill', 'zip-hover-line', 'zip-all-hit'].forEach((id) => {
@@ -958,6 +907,13 @@ document.addEventListener('DOMContentLoaded', async () => {
       if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', 'none');
     });
     clearHoveredZip();
+  };
+
+  const selectZip = (zip) => {
+    closeZipSelector();
+    zipInput.value = zip;
+    applyZip(zip);
+    showZipBoundary(zip);
   };
 
   zipBrowseBtn.addEventListener('click', () => {
@@ -979,7 +935,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   });
 
   // Load all Philadelphia ZCTA boundaries (called from map.on('load'))
-  const loadAllZipBoundaries = async () => {
+  loadAllZipBoundaries = async () => {
     try {
       const res = await fetch(
         "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/1/query?where=ZCTA5+LIKE+'191%25'&outFields=ZCTA5&outSR=4326&f=geojson",
@@ -1057,8 +1013,6 @@ document.addEventListener('DOMContentLoaded', async () => {
   };
 
   // Discrepancy filter — dims properties below threshold, highlights those above
-  const filterToggle = document.getElementById('filter-toggle');
-  const filterControls = document.getElementById('filter-controls');
   const thresholdSlider = document.getElementById('threshold-slider');
   const thresholdValue = document.getElementById('threshold-value');
 

--- a/ui/reviewer/main.js
+++ b/ui/reviewer/main.js
@@ -8,9 +8,9 @@ const metadataUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/con
 const currentBinsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/current_assessment_bins.json';
 const taxYearBinsUrl = 'https://storage.googleapis.com/musa5090s26-team6-public/configs/tax_year_assessment_bins.json';
 
-// 5-class sequential green palette (ColorBrewer YlGn → Greens)
+// 5-class sequential green palette (ColorBrewer)
 const valueColors = ['#f7fcf5', '#c7e9c0', '#74c476', '#31a354', '#006d2c'];
-// Diverging palette for change modes (ColorBrewer RdYlGn)
+// Diverging palette for change modes
 const pctStops = [-0.5, -0.2, -0.05, 0.05, 0.2, 0.5];
 const pctColors = ['#d73027', '#fc8d59', '#fee08b', '#d9ef8b', '#91cf60', '#1a9850'];
 
@@ -32,7 +32,7 @@ const fmtBp = (v) => {
   return `$${v}`;
 };
 
-// Build MapLibre 'step' expression from field and breakpoints array
+// Build MapLibre 'step' expression from field and breakpoints
 const makeValueColorExpr = (field, breakpoints) => {
   const expr = ['step', ['coalesce', ['to-number', ['get', field], 0], 0], valueColors[0]];
   breakpoints.forEach((bp, i) => {
@@ -89,7 +89,7 @@ const makeDollarChangeColorExpr = () => [
   '#ccc',
 ];
 
-// Update legend UI for given mode using live metadata breakpoints
+// Update legend inside #legend-box (vertical: high value at top, low at bottom)
 const updateLegend = (mode, metadata) => {
   const ramp = document.getElementById('legend-ramp');
   const labelsEl = document.getElementById('legend-labels');
@@ -98,21 +98,29 @@ const updateLegend = (mode, metadata) => {
   if (mode === 'current-value' || mode === 'tax-year-value') {
     const field = mode === 'current-value' ? 'current_assessed_value' : 'tax_year_assessed_value';
     const bps = metadata?.layers?.[field]?.breakpoints ?? [];
-    ramp.style.background = `linear-gradient(to right, ${valueColors.join(', ')})`;
+    // Vertical: darkest (high) at top → lightest (low) at bottom
+    ramp.style.background =
+      `linear-gradient(to bottom, ${[...valueColors].reverse().join(', ')})`;
     const maxLabel = mode === 'current-value' ? '$1.5M+' : '$1M+';
-    const labels = ['$0', ...bps.map(fmtBp), maxLabel];
+    // Labels top-to-bottom: high → low
+    const labels = [maxLabel, ...bps.map(fmtBp).reverse(), '$0'];
     labelsEl.innerHTML = labels.map((l) => `<span>${l}</span>`).join('');
     note.textContent = mode === 'current-value'
-      ? 'ML-predicted current assessed value'
-      : 'Tax year official assessed value';
+      ? 'ML predicted value'
+      : 'Tax year assessed value';
   } else if (mode === 'percent-change') {
-    ramp.style.background = `linear-gradient(to right, ${pctColors.join(', ')})`;
-    labelsEl.innerHTML = '<span>-50%</span><span>-20%</span><span>-5%</span><span>+5%</span><span>+20%</span><span>+50%+</span>';
-    note.textContent = 'Percent change from tax year to current prediction';
+    // Vertical: positive (green) at top, negative (red) at bottom
+    ramp.style.background =
+      `linear-gradient(to bottom, ${[...pctColors].reverse().join(', ')})`;
+    labelsEl.innerHTML =
+      '<span>+50%+</span><span>+20%</span><span>+5%</span><span>-5%</span><span>-20%</span><span>-50%</span>';
+    note.textContent = '% change (tax year → current)';
   } else {
-    ramp.style.background = `linear-gradient(to right, ${pctColors.join(', ')})`;
-    labelsEl.innerHTML = '<span>-$100k</span><span>-$50k</span><span>-$10k</span><span>+$10k</span><span>+$50k</span><span>+$100k+</span>';
-    note.textContent = 'Dollar change from tax year to current prediction';
+    ramp.style.background =
+      `linear-gradient(to bottom, ${[...pctColors].reverse().join(', ')})`;
+    labelsEl.innerHTML =
+      '<span>+$100k+</span><span>+$50k</span><span>+$10k</span><span>-$10k</span><span>-$50k</span><span>-$100k</span>';
+    note.textContent = '$ change (tax year → current)';
   }
 };
 
@@ -132,7 +140,7 @@ const medianFromBins = (bins) => {
   return bins[bins.length - 1]['lower_bound'];
 };
 
-// Render a bar chart of property counts by value bin for the most recent year
+// Render bar chart of property counts by value bin (most recent year)
 const renderBinsChart = (container, data) => {
   const hasTaxYear = data.length > 0 && 'tax_year' in data[0];
   let yearData, latestYear;
@@ -160,10 +168,10 @@ const renderBinsChart = (container, data) => {
 
   container.classList.add('chart-loaded');
 
-  const chart = new ApexCharts(container, {
+  new ApexCharts(container, {
     chart: {
       type: 'bar',
-      height: 180,
+      height: 150,
       toolbar: { show: false },
       animations: { enabled: false },
       fontFamily: '"Open Sans", system-ui, sans-serif',
@@ -171,14 +179,14 @@ const renderBinsChart = (container, data) => {
     series: [{ name: 'Properties', data: counts }],
     xaxis: {
       categories,
-      labels: { rotate: -45, style: { fontSize: '10px', colors: '#6d6d6d' } },
-      tickAmount: 10,
+      labels: { rotate: -45, style: { fontSize: '9px', colors: '#6d6d6d' } },
+      tickAmount: 8,
       axisBorder: { show: false },
       axisTicks: { show: false },
     },
     yaxis: {
       labels: {
-        style: { colors: '#6d6d6d', fontSize: '11px' },
+        style: { colors: '#6d6d6d', fontSize: '10px' },
         formatter: (v) => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v),
       },
     },
@@ -190,16 +198,13 @@ const renderBinsChart = (container, data) => {
     },
     grid: { borderColor: '#f0ede5', strokeDashArray: 4 },
     plotOptions: { bar: { columnWidth: '85%', borderRadius: 2 } },
-    states: {
-      hover: { filter: { type: 'darken', value: 0.8 } },
-    },
-  });
+    states: { hover: { filter: { type: 'darken', value: 0.8 } } },
+  }).render();
 
-  chart.render();
   return { yearData, latestYear };
 };
 
-// Render a year-over-year median value trend line chart
+// Render year-over-year median trend line chart
 const renderYearTrendChart = (container, data) => {
   const years = [...new Set(data.map((d) => d['tax_year']))].sort();
 
@@ -217,7 +222,7 @@ const renderYearTrendChart = (container, data) => {
   new ApexCharts(container, {
     chart: {
       type: 'area',
-      height: 180,
+      height: 150,
       toolbar: { show: false },
       animations: { enabled: false },
       fontFamily: '"Open Sans", system-ui, sans-serif',
@@ -225,13 +230,13 @@ const renderYearTrendChart = (container, data) => {
     series: [{ name: 'Median predicted value', data: yearPoints.map((d) => d.median) }],
     xaxis: {
       categories: yearPoints.map((d) => d.year),
-      labels: { style: { fontSize: '10px', colors: '#6d6d6d' } },
+      labels: { style: { fontSize: '9px', colors: '#6d6d6d' } },
       axisBorder: { show: false },
       axisTicks: { show: false },
     },
     yaxis: {
       labels: {
-        style: { colors: '#6d6d6d', fontSize: '11px' },
+        style: { colors: '#6d6d6d', fontSize: '10px' },
         formatter: (v) => v >= 1000 ? `$${(v / 1000).toFixed(0)}k` : `$${v}`,
       },
     },
@@ -241,72 +246,209 @@ const renderYearTrendChart = (container, data) => {
       type: 'gradient',
       gradient: { shade: 'light', type: 'vertical', opacityFrom: 0.35, opacityTo: 0.02 },
     },
-    stroke: { curve: 'smooth', width: 2.5 },
-    markers: { size: 4, colors: ['#0f4d90'], strokeColors: '#fff', strokeWidth: 2 },
-    tooltip: {
-      y: { formatter: (v) => currencyFmt.format(v) },
-      theme: 'light',
-    },
+    stroke: { curve: 'smooth', width: 2 },
+    markers: { size: 3, colors: ['#0f4d90'], strokeColors: '#fff', strokeWidth: 2 },
+    tooltip: { y: { formatter: (v) => currencyFmt.format(v) }, theme: 'light' },
     grid: { borderColor: '#f0ede5', strokeDashArray: 4 },
   }).render();
 };
 
-// Update summary stats in the info panel
-const updateSummary = (metadata, binsResult) => {
-  const tyCount = metadata?.layers?.tax_year_assessed_value?.count;
-  const curCount = metadata?.layers?.current_assessed_value?.count;
+// Compute median + total for a given tax year from bins data
+const computeStatsForYear = (data, year) => {
+  const yearBins = data
+    .filter((d) => d['tax_year'] === year && d['property_count'] > 0)
+    .sort((a, b) => a['lower_bound'] - b['lower_bound']);
+  if (yearBins.length === 0) return null;
+  const total = yearBins.reduce((s, d) => s + d['property_count'], 0);
+  const median = medianFromBins(yearBins);
+  return { total, median };
+};
 
-  const lines = [];
-  if (tyCount) lines.push(`${tyCount.toLocaleString()} properties with official tax year values.`);
-  if (curCount) lines.push(`${curCount.toLocaleString()} with ML-predicted current values.`);
+// Update OPA-focused overview
+// official median from tax year bins; ML median estimated from tile metadata breakpoints
+const updateSummaryForYear = (bins, year, metadata) => {
+  const stats = computeStatsForYear(bins, year);
+  if (!stats) return;
 
-  if (binsResult) {
-    const { yearData, latestYear } = binsResult;
-    const median = medianFromBins(yearData);
-    lines.push(`Median predicted value (${latestYear}): ${currencyFmt.format(Math.round(median))}.`);
+  const fmtCount = (n) => n >= 1000 ? `${(n / 1000).toFixed(0)}k` : String(n);
+
+  document.getElementById('stat-selected-year').textContent = year;
+  document.getElementById('stat-coverage').textContent = fmtCount(stats.total);
+  document.getElementById('stat-official-median').textContent = fmtBp(Math.round(stats.median));
+
+  const mlLayer = metadata?.layers?.current_assessed_value;
+  const mlBp = mlLayer?.breakpoints;
+  if (mlBp?.length >= 3) {
+    // Breakpoints divide ~418k properties into 5 roughly equal buckets.
+    // Median (50th pct) ≈ midpoint of the 3rd bucket (40–60th pct range).
+    const mlMedianEst = Math.round((mlBp[1] + mlBp[2]) / 2);
+    document.getElementById('stat-predicted-median').textContent = `~${fmtBp(mlMedianEst)}`;
+
+    const shift = (mlMedianEst - stats.median) / stats.median * 100;
+    const sign = shift >= 0 ? '+' : '';
+    const shiftEl = document.getElementById('stat-ratio');
+    shiftEl.textContent = `${sign}${shift.toFixed(1)}%`;
+    // Negative shift = market below official → possible over-assessment
+    shiftEl.style.color = shift > 5 ? '#31a354' : shift < -5 ? '#d73027' : '#6d6d6d';
+  }
+};
+
+// Render year selector pill buttons
+const renderYearSelector = (container, years, defaultYear, onSelect) => {
+  years.forEach((year) => {
+    const btn = document.createElement('button');
+    btn.className = `year-btn${year === defaultYear ? ' active' : ''}`;
+    btn.textContent = year;
+    btn.addEventListener('click', () => {
+      container.querySelectorAll('.year-btn').forEach((b) => b.classList.remove('active'));
+      btn.classList.add('active');
+      onSelect(year);
+    });
+    container.appendChild(btn);
+  });
+};
+
+// Persistent chart instance for tax year distribution (updates on year change)
+let taxYearChartInstance = null;
+
+const renderTaxYearChart = (container, data, year) => {
+  const yearData = data
+    .filter((d) => d['tax_year'] === year && d['lower_bound'] < 2000000)
+    .sort((a, b) => a['lower_bound'] - b['lower_bound']);
+
+  if (yearData.length === 0) return;
+
+  const categories = yearData.map((d) => {
+    const lb = d['lower_bound'];
+    return lb >= 1000 ? `$${(lb / 1000).toFixed(0)}k` : `$${lb}`;
+  });
+  const counts = yearData.map((d) => d['property_count']);
+
+  if (taxYearChartInstance) {
+    taxYearChartInstance.updateOptions({ xaxis: { categories } }, false, false);
+    taxYearChartInstance.updateSeries([{ name: 'Properties', data: counts }]);
+    return;
   }
 
-  document.getElementById('summary-text').innerHTML =
-    lines.length > 0 ? lines.join('<br>') : 'Loading assessment data…';
+  container.classList.add('chart-loaded');
+  taxYearChartInstance = new ApexCharts(container, {
+    chart: {
+      type: 'bar',
+      height: 150,
+      toolbar: { show: false },
+      animations: { enabled: false },
+      fontFamily: '"Open Sans", system-ui, sans-serif',
+    },
+    series: [{ name: 'Properties', data: counts }],
+    xaxis: {
+      categories,
+      labels: { rotate: -45, style: { fontSize: '9px', colors: '#6d6d6d' } },
+      tickAmount: 8,
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+    },
+    yaxis: {
+      labels: {
+        style: { colors: '#6d6d6d', fontSize: '10px' },
+        formatter: (v) => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v),
+      },
+    },
+    dataLabels: { enabled: false },
+    colors: ['#0f4d90'],
+    tooltip: { y: { formatter: (v) => `${v.toLocaleString()} properties` }, theme: 'light' },
+    grid: { borderColor: '#f0ede5', strokeDashArray: 4 },
+    plotOptions: { bar: { columnWidth: '85%', borderRadius: 2 } },
+    states: { hover: { filter: { type: 'darken', value: 0.8 } } },
+  });
+  taxYearChartInstance.render();
 };
 
 const loadCharts = async (metadata) => {
   const taxYearEl = document.getElementById('current-value-chart');
   const predictedEl = document.getElementById('percent-change-chart');
 
+  // Load both bin datasets in parallel
+  let taxYearBinsData = null;
   let currentBinsData = null;
   try {
-    const res = await fetch(currentBinsUrl);
-    if (res.ok) currentBinsData = await res.json();
+    const [taxRes, curRes] = await Promise.all([fetch(taxYearBinsUrl), fetch(currentBinsUrl)]);
+    if (taxRes.ok) taxYearBinsData = await taxRes.json();
+    if (curRes.ok) currentBinsData = await curRes.json();
   } catch { /* noop */ }
 
-  // Chart 1: try official tax year bins; fall back to year-over-year trend
-  let chart1Loaded = false;
-  try {
-    const res = await fetch(taxYearBinsUrl);
-    if (res.ok) {
-      const data = await res.json();
-      renderBinsChart(taxYearEl, data);
-      chart1Loaded = true;
-    }
-  } catch { /* noop */ }
+  // Chart 1: tax year distribution with year selector
+  if (taxYearBinsData) {
+    // All years with substantial data (for YoY lookup even outside selector)
+    const allYears = [...new Set(taxYearBinsData.map((d) => d['tax_year']))]
+      .sort()
+      .filter((y) =>
+        taxYearBinsData
+          .filter((d) => d['tax_year'] === y)
+          .reduce((s, d) => s + d['property_count'], 0) > 10000,
+      );
 
-  if (!chart1Loaded) {
-    const hasTaxYear = currentBinsData?.length > 0 && 'tax_year' in currentBinsData[0];
-    if (currentBinsData && hasTaxYear) {
-      renderYearTrendChart(taxYearEl, currentBinsData);
-      document.getElementById('chart1-title').textContent = 'Predicted value trend';
-      document.getElementById('chart1-subtitle').textContent =
-        'Median ML-predicted assessed value by year';
+    // Selector shows the most recent 4 years with >100k properties
+    const significantYears = allYears
+      .filter((y) =>
+        taxYearBinsData
+          .filter((d) => d['tax_year'] === y)
+          .reduce((s, d) => s + d['property_count'], 0) > 100000,
+      )
+      .slice(-4);
+
+    if (significantYears.length > 0) {
+      const defaultYear = significantYears.at(-1);
+      const selectorEl = document.getElementById('year-selector');
+
+      renderYearSelector(selectorEl, significantYears, defaultYear, (year) => {
+        renderTaxYearChart(taxYearEl, taxYearBinsData, year);
+        updateSummaryForYear(taxYearBinsData, year, metadata);
+      });
+
+      renderTaxYearChart(taxYearEl, taxYearBinsData, defaultYear);
+      updateSummaryForYear(taxYearBinsData, defaultYear, metadata);
     }
   }
 
-  // Chart 2: distribution histogram for the most recent year in current bins
-  if (currentBinsData) {
-    const result = renderBinsChart(predictedEl, currentBinsData);
-    updateSummary(metadata, result);
-  } else {
-    updateSummary(metadata, null);
+  // Chart 2: ML prediction distribution
+  if (currentBinsData) renderBinsChart(predictedEl, currentBinsData);
+};
+
+// Debounce utility
+const debounce = (fn, delay) => {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+};
+
+// Fetch address suggestions from Photon (OSM-based, Philadelphia bounded)
+const fetchSuggestions = async (query) => {
+  if (query.length < 3) return [];
+  try {
+    const url = new URL('https://photon.komoot.io/api/');
+    url.searchParams.set('q', `${query} Philadelphia`);
+    url.searchParams.set('limit', '6');
+    url.searchParams.set('bbox', '-75.2803,39.8676,-74.9558,40.1379');
+    url.searchParams.set('lang', 'en');
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    return data.features.map((f) => {
+      const p = f.properties;
+      const parts = [];
+      if (p['housenumber']) parts.push(p['housenumber']);
+      if (p['street']) parts.push(p['street']);
+      else if (p['name']) parts.push(p['name']);
+      if (p['city']) parts.push(p['city']);
+      if (p['postcode']) parts.push(p['postcode']);
+      return {
+        label: parts.join(', '),
+        lngLat: [f.geometry.coordinates[0], f.geometry.coordinates[1]],
+      };
+    }).filter((s) => s.label.length > 0);
+  } catch {
+    return [];
   }
 };
 
@@ -316,7 +458,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   try {
     const res = await fetch(metadataUrl);
     if (res.ok) metadata = await res.json();
-  } catch { /* fall back to hardcoded defaults below */ }
+  } catch { /* fall back to defaults */ }
 
   const currentBreakpoints = metadata?.layers?.current_assessed_value?.breakpoints
     ?? [50000, 100000, 200000, 500000];
@@ -332,9 +474,10 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   map.addControl(new maplibregl.NavigationControl(), 'top-left');
 
-  // Set initial legend from metadata
-  updateLegend('tax-year-value', metadata);
+  // Set initial legend (default mode: percent-change)
+  updateLegend('percent-change', metadata);
 
+  // Zoom hint
   const zoomHint = document.getElementById('zoom-hint');
   const updateZoomHint = () => {
     zoomHint.style.display = map.getZoom() < 12 ? 'block' : 'none';
@@ -357,7 +500,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       source: 'properties',
       'source-layer': sourceLayer,
       paint: {
-        'fill-color': makeValueColorExpr('tax_year_assessed_value', taxYearBreakpoints),
+        'fill-color': makePctChangeColorExpr(),
         'fill-opacity': 0.78,
       },
     });
@@ -398,15 +541,21 @@ document.addEventListener('DOMContentLoaded', async () => {
         'line-width': 2,
       },
     });
+
+    // Load all Philadelphia ZCTA boundaries for the zip selector
+    loadAllZipBoundaries();
   });
 
+  let activeMode = 'percent-change';
+
+  // Layer control
   const layerControl = document.getElementById('map-layer-control');
   layerControl.addEventListener('change', (e) => {
     if (!map.isStyleLoaded()) return;
 
     const mode = e.target.value;
-    let colorExpr;
 
+    let colorExpr;
     if (mode === 'current-value') {
       colorExpr = makeValueColorExpr('current_assessed_value', currentBreakpoints);
     } else if (mode === 'tax-year-value') {
@@ -419,17 +568,92 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     map.setPaintProperty('properties-fill', 'fill-color', colorExpr);
     updateLegend(mode, metadata);
+    activeMode = mode;
   });
 
-  map.on('mouseenter', 'properties-fill', () => {
+  // Hover tooltip (lightweight, follows cursor)
+  const hoverTooltip = document.getElementById('hover-tooltip');
+  const mapEl = document.getElementById('property-map');
+  const tooltipValueLabel = document.getElementById('tooltip-value-label');
+  const tooltipChangeLabel = document.getElementById('tooltip-change-label');
+  const tooltipChangeVal = document.getElementById('tooltip-change');
+
+  map.on('mousemove', 'properties-fill', (e) => {
+    if (!e.features || e.features.length === 0) return;
+
+    const featureProps = e.features[0].properties;
+    const rect = mapEl.getBoundingClientRect();
+    const x = e.originalEvent.clientX - rect.left;
+    const y = e.originalEvent.clientY - rect.top;
+
+    // Flip tooltip to left side if near right edge
+    const ttWidth = 210;
+    const leftPos = x + ttWidth + 20 > rect.width ? x - ttWidth - 8 : x + 14;
+    hoverTooltip.style.left = `${leftPos}px`;
+    hoverTooltip.style.top = `${Math.max(0, y - 20)}px`;
+
+    hoverTooltip.querySelector('.tooltip-address').textContent =
+      featureProps['address'] || 'Unknown address';
+    document.getElementById('tooltip-id').textContent =
+      featureProps['property_id'] || '—';
+
+    const curNum = Number(featureProps['current_assessed_value']) || 0;
+    const taxNum = Number(featureProps['tax_year_assessed_value']) || 0;
+
+    if (activeMode === 'tax-year-value') {
+      tooltipValueLabel.textContent = 'Tax year';
+      document.getElementById('tooltip-value').textContent = formatCurrency(taxNum);
+      tooltipChangeLabel.hidden = true;
+      tooltipChangeVal.hidden = true;
+    } else {
+      tooltipValueLabel.textContent = 'ML predicted';
+      document.getElementById('tooltip-value').textContent = formatCurrency(curNum);
+      if (curNum > 0 && taxNum > 0 && (activeMode === 'percent-change' || activeMode === 'dollar-change')) {
+        const diff = curNum - taxNum;
+        const sign = diff >= 0 ? '+' : '';
+        tooltipChangeLabel.textContent = 'vs. tax year';
+        tooltipChangeVal.textContent = activeMode === 'percent-change'
+          ? `${sign}${((diff / taxNum) * 100).toFixed(1)}%`
+          : diff >= 0 ? `+${formatCurrency(diff)}` : formatCurrency(diff);
+        tooltipChangeLabel.removeAttribute('hidden');
+        tooltipChangeVal.removeAttribute('hidden');
+      } else {
+        tooltipChangeLabel.hidden = true;
+        tooltipChangeVal.hidden = true;
+      }
+    }
+
+    hoverTooltip.removeAttribute('hidden');
     map.getCanvas().style.cursor = 'pointer';
   });
 
   map.on('mouseleave', 'properties-fill', () => {
+    hoverTooltip.setAttribute('hidden', '');
     map.getCanvas().style.cursor = '';
   });
 
+  // MapLibre native popup — anchors to geo coordinate, stays with property on pan
+  const mapPopup = new maplibregl.Popup({
+    closeButton: true,
+    closeOnClick: false,
+    anchor: 'top',
+    offset: [0, 6],
+    className: 'map-popup',
+  });
+
+  mapPopup.on('close', () => {
+    const emptyFilter = ['==', ['get', 'property_id'], ''];
+    if (map.getLayer('properties-selected')) {
+      map.setFilter('properties-selected', emptyFilter);
+      map.setFilter('properties-selected-outline', emptyFilter);
+    }
+  });
+
+  // Click popup (detailed, appears below clicked point)
   map.on('click', 'properties-fill', (e) => {
+    if (!e.features || e.features.length === 0) return;
+    if (zipSelectorEl && !zipSelectorEl.hidden) return; // zip selector intercepts clicks
+
     const featureProps = e.features[0].properties;
     const address = featureProps['address'];
     const propertyId = featureProps['property_id'];
@@ -443,28 +667,450 @@ document.addEventListener('DOMContentLoaded', async () => {
       changeText = `${formatCurrency(change)} (${Number(pct) > 0 ? '+' : ''}${pct}%)`;
     }
 
-    // Update floating popup
-    const popup = document.getElementById('property-popup');
-    popup.removeAttribute('hidden');
-    popup.querySelector('.popup-address').textContent = address || 'Unknown address';
-    const popupDds = popup.querySelectorAll('dd');
-    popupDds[0].textContent = formatCurrency(curVal);
-    popupDds[1].textContent = formatCurrency(taxVal);
-    popupDds[2].textContent = changeText;
+    const changeNum = (curVal && taxVal && Number(taxVal) > 0)
+      ? Number(curVal) - Number(taxVal) : null;
+    const changeClass = changeNum === null ? '' : changeNum >= 0 ? 'change-pos' : 'change-neg';
 
-    // Update info panel
-    document.getElementById('no-selection-hint').hidden = true;
-    document.getElementById('property-detail-list').removeAttribute('hidden');
-    document.getElementById('info-address').textContent = address || '—';
-    document.getElementById('info-property-id').textContent = propertyId || '—';
-    document.getElementById('info-current-value').textContent = formatCurrency(curVal);
-    document.getElementById('info-tax-year-value').textContent = formatCurrency(taxVal);
-    document.getElementById('info-change').textContent = changeText;
+    const widgetLink = propertyId
+      ? `<a href="../widget/?parcel_number=${encodeURIComponent(propertyId)}" class="popup-link">View full history →</a>`
+      : '';
 
-    // Highlight selected parcel
+    mapPopup
+      .setLngLat(e.lngLat)
+      .setHTML(`
+        <p class="popup-address">${address || 'Unknown address'}</p>
+        <dl class="popup-details">
+          <dt>Property ID</dt><dd>${propertyId || '—'}</dd>
+          <dt>ML predicted</dt><dd>${formatCurrency(curVal)}</dd>
+          <dt>Tax year value</dt><dd>${formatCurrency(taxVal)}</dd>
+          <dt>Change</dt><dd class="${changeClass}">${changeText}</dd>
+        </dl>
+        ${widgetLink}
+      `)
+      .addTo(map);
+
+    hoverTooltip.setAttribute('hidden', '');
+
     const idFilter = ['==', ['get', 'property_id'], propertyId ?? ''];
     map.setFilter('properties-selected', idFilter);
     map.setFilter('properties-selected-outline', idFilter);
+  });
+
+  // Shared reference needed by both popup and zip selector
+  const zipSelectorEl = document.getElementById('zip-selector');
+
+  // Address autocomplete (Photon OSM, Philadelphia bounded)
+  const addressInput = document.getElementById('address-input');
+  const addressBtn = document.getElementById('address-search-btn');
+  const addressClearBtn = document.getElementById('address-clear');
+  const suggestionsEl = document.getElementById('address-suggestions');
+
+  let activeSuggestions = [];
+  let activeIndex = -1;
+
+  const renderSuggestions = (suggestions) => {
+    activeSuggestions = suggestions;
+    activeIndex = -1;
+    suggestionsEl.innerHTML = '';
+
+    if (suggestions.length === 0) {
+      suggestionsEl.hidden = true;
+      addressInput.setAttribute('aria-expanded', 'false');
+      return;
+    }
+
+    suggestions.forEach((s, i) => {
+      const item = document.createElement('div');
+      item.className = 'suggestion-item';
+      item.setAttribute('role', 'option');
+      item.textContent = s.label;
+      item.addEventListener('mousedown', (ev) => {
+        ev.preventDefault();
+        addressInput.value = s.label;
+        suggestionsEl.hidden = true;
+        addressInput.setAttribute('aria-expanded', 'false');
+        map.flyTo({ center: s.lngLat, zoom: 17 });
+      });
+      suggestionsEl.appendChild(item);
+      void i;
+    });
+
+    suggestionsEl.hidden = false;
+    addressInput.setAttribute('aria-expanded', 'true');
+  };
+
+  const debouncedFetch = debounce(async (query) => {
+    const results = await fetchSuggestions(query);
+    renderSuggestions(results);
+  }, 280);
+
+  addressInput.addEventListener('input', () => {
+    const q = addressInput.value.trim();
+    addressClearBtn.hidden = q.length === 0;
+    if (q.length >= 3) {
+      debouncedFetch(q);
+    } else {
+      suggestionsEl.hidden = true;
+    }
+  });
+
+  addressClearBtn.addEventListener('click', () => {
+    addressInput.value = '';
+    addressClearBtn.hidden = true;
+    suggestionsEl.hidden = true;
+    addressInput.setAttribute('aria-expanded', 'false');
+    activeSuggestions = [];
+    const emptyFilter = ['==', ['get', 'property_id'], ''];
+    if (map.getLayer('properties-selected')) {
+      map.setFilter('properties-selected', emptyFilter);
+      map.setFilter('properties-selected-outline', emptyFilter);
+    }
+    mapPopup.remove();
+    addressInput.focus();
+  });
+
+  addressInput.addEventListener('keydown', (e) => {
+    const items = suggestionsEl.querySelectorAll('.suggestion-item');
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, items.length - 1);
+      items.forEach((el, i) => el.classList.toggle('active', i === activeIndex));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, -1);
+      items.forEach((el, i) => el.classList.toggle('active', i === activeIndex));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (activeIndex >= 0 && activeSuggestions[activeIndex]) {
+        const s = activeSuggestions[activeIndex];
+        addressInput.value = s.label;
+        suggestionsEl.hidden = true;
+        map.flyTo({ center: s.lngLat, zoom: 17 });
+      } else if (activeSuggestions.length > 0) {
+        const s = activeSuggestions[0];
+        addressInput.value = s.label;
+        suggestionsEl.hidden = true;
+        map.flyTo({ center: s.lngLat, zoom: 17 });
+      }
+    } else if (e.key === 'Escape') {
+      suggestionsEl.hidden = true;
+      addressInput.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  addressInput.addEventListener('blur', () => {
+    setTimeout(() => {
+      suggestionsEl.hidden = true;
+      addressInput.setAttribute('aria-expanded', 'false');
+    }, 150);
+  });
+
+  addressBtn.addEventListener('click', async () => {
+    const q = addressInput.value.trim();
+    if (!q) return;
+    if (activeSuggestions.length > 0) {
+      const s = activeSuggestions[0];
+      map.flyTo({ center: s.lngLat, zoom: 17 });
+      suggestionsEl.hidden = true;
+    } else {
+      const results = await fetchSuggestions(q);
+      if (results.length > 0) {
+        map.flyTo({ center: results[0].lngLat, zoom: 17 });
+      } else {
+        addressInput.style.outline = '2px solid #d73027';
+        setTimeout(() => { addressInput.style.outline = ''; }, 2000);
+      }
+    }
+  });
+
+  // Zip code filter
+  const zipInput = document.getElementById('zip-input');
+  const zipClear = document.getElementById('zip-clear');
+  let activeZip = null;
+
+  const clearZipBoundary = () => {
+    if (map.getSource('zip-boundary')) {
+      map.getSource('zip-boundary').setData({ type: 'FeatureCollection', features: [] });
+    }
+  };
+
+  const applyZip = (zip) => {
+    activeZip = zip || null;
+    zipClear.hidden = !activeZip;
+    if (!activeZip) {
+      clearZipBoundary();
+      // Restore property layers to full visibility
+      map.setFilter('properties-fill', null);
+      map.setFilter('properties-outline', null);
+    }
+    if (activeZip && filterToggle.checked) {
+      filterToggle.checked = false;
+      filterControls.hidden = true;
+    }
+  };
+
+  const showZipBoundary = async (zip) => {
+    try {
+      // Census TIGER ZCTA boundaries (single call for polygon + bounding box)
+      const res = await fetch(
+        `https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/1/query?where=ZCTA5%3D'${encodeURIComponent(zip)}'&outFields=ZCTA5&outSR=4326&f=geojson`,
+      );
+      const geojson = await res.json();
+      const feature = geojson.features?.[0];
+      if (!feature) return;
+
+      // Compute bounding box from polygon coordinates
+      const allCoords = feature.geometry.type === 'Polygon'
+        ? feature.geometry.coordinates[0]
+        : feature.geometry.coordinates.flatMap((poly) => poly[0]);
+      const lons = allCoords.map((p) => p[0]);
+      const lats = allCoords.map((p) => p[1]);
+      const west = Math.min(...lons);
+      const east = Math.max(...lons);
+      const south = Math.min(...lats);
+      const north = Math.max(...lats);
+
+      // Fly to zip area, minZoom 12 ensures property tiles load
+      map.fitBounds([[west, south], [east, north]], { padding: 60, maxZoom: 14, minZoom: 12 });
+
+      // Draw boundary
+      const fc = { type: 'FeatureCollection', features: [feature] };
+      if (map.getSource('zip-boundary')) {
+        map.getSource('zip-boundary').setData(fc);
+      } else {
+        map.addSource('zip-boundary', { type: 'geojson', data: fc });
+        // Subtle yellow fill sits beneath the property tile layer
+        map.addLayer({
+          id: 'zip-boundary-fill',
+          type: 'fill',
+          source: 'zip-boundary',
+          paint: { 'fill-color': '#f3c613', 'fill-opacity': 0.10 },
+        }, 'properties-fill');
+        // Dashed blue border on top of everything
+        map.addLayer({
+          id: 'zip-boundary-line',
+          type: 'line',
+          source: 'zip-boundary',
+          paint: {
+            'line-color': '#0f4d90',
+            'line-width': 2.5,
+            'line-dasharray': [5, 3],
+          },
+        });
+      }
+    } catch { /* ignore */ }
+  };
+
+  zipInput.addEventListener('input', () => {
+    const val = zipInput.value.trim();
+    if (val.length === 5 && /^\d{5}$/.test(val)) {
+      applyZip(val);
+      showZipBoundary(val);
+    } else if (val.length === 0) {
+      applyZip(null);
+    }
+  });
+
+  zipClear.addEventListener('click', () => {
+    zipInput.value = '';
+    applyZip(null);
+  });
+
+  // ── Zip selector (browse all Philadelphia zip codes) ──────────────────
+
+  const zipListEl = document.getElementById('zip-list');
+  const zipBrowseBtn = document.getElementById('zip-browse-btn');
+  const zipSelectorClose = document.getElementById('zip-selector-close');
+
+  const setHoveredZip = (zip) => {
+    if (map.getLayer('zip-hover-fill')) {
+      const f = zip ? ['==', ['get', 'ZCTA5'], zip] : ['==', ['get', 'ZCTA5'], ''];
+      map.setFilter('zip-hover-fill', f);
+      map.setFilter('zip-hover-line', f);
+    }
+    zipListEl.querySelectorAll('.zip-item').forEach((el) => {
+      const isMatch = el.dataset.zip === zip;
+      el.classList.toggle('hovered', isMatch);
+      if (isMatch) el.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    });
+  };
+
+  const clearHoveredZip = () => setHoveredZip(null);
+
+  const selectZip = (zip) => {
+    closeZipSelector();
+    zipInput.value = zip;
+    applyZip(zip);
+    showZipBoundary(zip);
+  };
+
+  const openZipSelector = () => {
+    zipSelectorEl.removeAttribute('hidden');
+    ['zip-all-line', 'zip-hover-fill', 'zip-hover-line', 'zip-all-hit'].forEach((id) => {
+      if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', 'visible');
+    });
+  };
+
+  const closeZipSelector = () => {
+    zipSelectorEl.hidden = true;
+    ['zip-all-line', 'zip-hover-fill', 'zip-hover-line', 'zip-all-hit'].forEach((id) => {
+      if (map.getLayer(id)) map.setLayoutProperty(id, 'visibility', 'none');
+    });
+    clearHoveredZip();
+  };
+
+  zipBrowseBtn.addEventListener('click', () => {
+    zipSelectorEl.hidden ? openZipSelector() : closeZipSelector();
+  });
+
+  zipSelectorClose.addEventListener('click', closeZipSelector);
+
+  zipListEl.addEventListener('mouseover', (e) => {
+    const item = e.target.closest('.zip-item');
+    if (item) setHoveredZip(item.dataset.zip);
+  });
+
+  zipListEl.addEventListener('mouseleave', clearHoveredZip);
+
+  zipListEl.addEventListener('click', (e) => {
+    const item = e.target.closest('.zip-item');
+    if (item) selectZip(item.dataset.zip);
+  });
+
+  // Load all Philadelphia ZCTA boundaries (called from map.on('load'))
+  const loadAllZipBoundaries = async () => {
+    try {
+      const res = await fetch(
+        "https://tigerweb.geo.census.gov/arcgis/rest/services/TIGERweb/PUMA_TAD_TAZ_UGA_ZCTA/MapServer/1/query?where=ZCTA5+LIKE+'191%25'&outFields=ZCTA5&outSR=4326&f=geojson",
+      );
+      const data = await res.json();
+      if (!data.features?.length) return;
+
+      map.addSource('zip-all', { type: 'geojson', data });
+
+      // Thin gray lines for all zip areas
+      map.addLayer({
+        id: 'zip-all-line',
+        type: 'line',
+        source: 'zip-all',
+        layout: { visibility: 'none' },
+        paint: { 'line-color': '#0f4d90', 'line-width': 1, 'line-opacity': 0.25 },
+      });
+
+      // Invisible fill for hover hit-testing
+      map.addLayer({
+        id: 'zip-all-hit',
+        type: 'fill',
+        source: 'zip-all',
+        layout: { visibility: 'none' },
+        paint: { 'fill-color': '#000', 'fill-opacity': 0 },
+      });
+
+      // Yellow highlight fill for hovered zip
+      map.addLayer({
+        id: 'zip-hover-fill',
+        type: 'fill',
+        source: 'zip-all',
+        layout: { visibility: 'none' },
+        filter: ['==', ['get', 'ZCTA5'], ''],
+        paint: { 'fill-color': '#f3c613', 'fill-opacity': 0.18 },
+      });
+
+      // Bold border for hovered zip
+      map.addLayer({
+        id: 'zip-hover-line',
+        type: 'line',
+        source: 'zip-all',
+        layout: { visibility: 'none' },
+        filter: ['==', ['get', 'ZCTA5'], ''],
+        paint: { 'line-color': '#0f4d90', 'line-width': 2.5 },
+      });
+
+      // Map interactions (only active when selector is open)
+      map.on('mousemove', 'zip-all-hit', (e) => {
+        if (zipSelectorEl.hidden) return;
+        map.getCanvas().style.cursor = 'pointer';
+        const zip = e.features?.[0]?.properties?.ZCTA5;
+        if (zip) setHoveredZip(zip);
+      });
+
+      map.on('mouseleave', 'zip-all-hit', () => {
+        if (!zipSelectorEl.hidden) {
+          map.getCanvas().style.cursor = '';
+          clearHoveredZip();
+        }
+      });
+
+      map.on('click', 'zip-all-hit', (e) => {
+        if (zipSelectorEl.hidden) return;
+        const zip = e.features?.[0]?.properties?.ZCTA5;
+        if (zip) selectZip(zip);
+      });
+
+      // Populate list
+      const zips = data.features.map((f) => f.properties.ZCTA5).sort();
+      zipListEl.innerHTML = zips
+        .map((z) => `<div class="zip-item" data-zip="${z}">${z}</div>`)
+        .join('');
+    } catch { /* ignore */ }
+  };
+
+  // Discrepancy filter — dims properties below threshold, highlights those above
+  const filterToggle = document.getElementById('filter-toggle');
+  const filterControls = document.getElementById('filter-controls');
+  const thresholdSlider = document.getElementById('threshold-slider');
+  const thresholdValue = document.getElementById('threshold-value');
+
+  // Build MapLibre filter expression: keep only properties where |change%| >= threshold
+  const buildDiscrepancyFilter = (threshold) => [
+    'all',
+    ['>', ['coalesce', ['to-number', ['get', 'current_assessed_value'], 0], 0], 0],
+    ['>', ['coalesce', ['to-number', ['get', 'tax_year_assessed_value'], 0], 0], 0],
+    [
+      '>=',
+      [
+        'abs',
+        [
+          '/',
+          ['-', ['to-number', ['get', 'current_assessed_value']], ['to-number', ['get', 'tax_year_assessed_value']]],
+          ['to-number', ['get', 'tax_year_assessed_value']],
+        ],
+      ],
+      threshold / 100,
+    ],
+  ];
+
+  const applyDiscrepancyFilter = (threshold) => {
+    map.setFilter('properties-fill', buildDiscrepancyFilter(threshold));
+    map.setFilter('properties-outline', buildDiscrepancyFilter(threshold));
+  };
+
+  const resetFilter = () => {
+    map.setFilter('properties-fill', null);
+    map.setFilter('properties-outline', null);
+  };
+
+  filterToggle.addEventListener('change', () => {
+    if (filterToggle.checked) {
+      filterControls.hidden = false;
+      if (activeZip) {
+        zipInput.value = '';
+        activeZip = null;
+        zipClear.hidden = true;
+        clearZipBoundary();
+      }
+      applyDiscrepancyFilter(Number(thresholdSlider.value));
+    } else {
+      filterControls.hidden = true;
+      resetFilter();
+    }
+  });
+
+  thresholdSlider.addEventListener('input', () => {
+    const val = Number(thresholdSlider.value);
+    thresholdValue.textContent = `${val}%`;
+    if (filterToggle.checked) applyDiscrepancyFilter(val);
   });
 
   loadCharts(metadata);

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -209,6 +209,7 @@ body {
 }
 
 #address-search-btn:hover { background: #0a3060; }
+
 #address-search-btn:disabled {
   opacity: 0.6;
   cursor: default;

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -186,6 +186,7 @@ body {
 }
 
 #address-clear:hover { color: var(--dark); }
+
 #address-clear svg { width: 14px; height: 14px; }
 
 #address-search-btn {
@@ -351,6 +352,7 @@ body {
 }
 
 #zip-browse-btn:hover { background: var(--blue-pale); color: var(--blue); }
+
 #zip-browse-btn svg { width: 14px; height: 14px; }
 
 /* ── Zip selector panel ──────────────────────────────── */

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -65,7 +65,10 @@ body {
 
 .city-bar-back:hover { opacity: 1; }
 
-.city-bar-title { flex: 1; text-align: center; }
+.city-bar-title {
+  flex: 1;
+  text-align: center;
+}
 
 .city-bar-dept {
   font-weight: 500;
@@ -187,7 +190,10 @@ body {
 
 #address-clear:hover { color: var(--dark); }
 
-#address-clear svg { width: 14px; height: 14px; }
+#address-clear svg {
+  width: 14px;
+  height: 14px;
+}
 
 #address-search-btn {
   background: var(--blue);
@@ -198,12 +204,15 @@ body {
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  border-radius: 0 0 8px 0;
+  border-radius: 0 0 8px;
   transition: background 0.15s;
 }
 
 #address-search-btn:hover { background: #0a3060; }
-#address-search-btn:disabled { opacity: 0.6; cursor: default; }
+#address-search-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
 
 #address-search-btn svg {
   width: 15px;
@@ -315,7 +324,7 @@ body {
   outline: none;
   background: transparent;
   min-width: 0;
-  border-radius: 8px 0 0 0;
+  border-radius: 8px 0 0;
 }
 
 #zip-input::placeholder { color: #b0a9a0; }
@@ -351,9 +360,15 @@ body {
   transition: background 0.15s, color 0.15s;
 }
 
-#zip-browse-btn:hover { background: var(--blue-pale); color: var(--blue); }
+#zip-browse-btn:hover {
+  background: var(--blue-pale);
+  color: var(--blue);
+}
 
-#zip-browse-btn svg { width: 14px; height: 14px; }
+#zip-browse-btn svg {
+  width: 14px;
+  height: 14px;
+}
 
 /* ── Zip selector panel ──────────────────────────────── */
 #zip-selector {
@@ -496,8 +511,15 @@ body {
   font-size: 11px;
 }
 
-.tooltip-dl dt { color: rgb(255 255 255 / 65%); white-space: nowrap; }
-.tooltip-dl dd { margin: 0; font-weight: 500; }
+.tooltip-dl dt {
+  color: rgb(255 255 255 / 65%);
+  white-space: nowrap;
+}
+
+.tooltip-dl dd {
+  margin: 0;
+  font-weight: 500;
+}
 
 /* ── MapLibre popup (shown near clicked property) ────── */
 .map-popup .maplibregl-popup-content {
@@ -543,8 +565,17 @@ body {
   gap: 5px 12px;
 }
 
-.popup-details dt { color: var(--gray-600); white-space: nowrap; font-size: 12px; }
-.popup-details dd { margin: 0; font-weight: 600; font-size: 12px; }
+.popup-details dt {
+  color: var(--gray-600);
+  white-space: nowrap;
+  font-size: 12px;
+}
+
+.popup-details dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 12px;
+}
 .change-pos { color: #31a354; }
 .change-neg { color: #d73027; }
 

--- a/ui/reviewer/style.css
+++ b/ui/reviewer/style.css
@@ -31,21 +31,10 @@ body {
   font-family: var(--font-body);
   color: var(--dark);
   background: var(--gray-100);
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
-}
-
-/* ── Accessibility ──────────────────────────────────── */
-.visually-hidden {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
   overflow: hidden;
-  clip-path: inset(50%);
-  border: 0;
 }
 
 /* ── City bar ───────────────────────────────────────── */
@@ -74,14 +63,9 @@ body {
   white-space: nowrap;
 }
 
-.city-bar-back:hover {
-  opacity: 1;
-}
+.city-bar-back:hover { opacity: 1; }
 
-.city-bar-title {
-  flex: 1;
-  text-align: center;
-}
+.city-bar-title { flex: 1; text-align: center; }
 
 .city-bar-dept {
   font-weight: 500;
@@ -93,10 +77,9 @@ body {
 #reviewer-header {
   background: var(--blue);
   padding: 0 20px;
-  height: 52px;
+  height: 48px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   flex-shrink: 0;
   box-shadow: 0 2px 8px rgb(0 0 0 / 20%);
 }
@@ -108,8 +91,8 @@ body {
 }
 
 .header-icon {
-  width: 32px;
-  height: 32px;
+  width: 28px;
+  height: 28px;
   background: rgb(255 255 255 / 15%);
   border-radius: 6px;
   display: flex;
@@ -118,8 +101,8 @@ body {
 }
 
 .header-icon svg {
-  width: 16px;
-  height: 16px;
+  width: 14px;
+  height: 14px;
   stroke: #fff;
 }
 
@@ -132,14 +115,11 @@ body {
   letter-spacing: 0.2px;
 }
 
-/* ── Main grid ──────────────────────────────────────── */
+/* ── Main grid (map + info panel, fills remaining height) */
 #reviewer-main {
   flex: 1;
   display: grid;
-  grid-template:
-    "map info" minmax(420px, 1fr)
-    "charts charts" auto
-    / 2fr 1fr;
+  grid-template: "map info" 1fr / 2fr 1fr;
   gap: 2px;
   background: var(--border);
   padding: 2px;
@@ -151,7 +131,7 @@ body {
   grid-area: map;
   background: var(--white);
   position: relative;
-  min-height: 420px;
+  overflow: hidden;
 }
 
 #property-map {
@@ -159,19 +139,129 @@ body {
   height: 100%;
 }
 
-/* ── Layer toggle ───────────────────────────────────── */
-#map-layer-control {
+/* ── Search panel (address + zip, top-left) ─────────── */
+#search-panel {
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 10px;
+  left: 48px;
+  z-index: 1000;
+  width: 280px;
+  background: var(--white);
+  border-radius: 8px;
+  box-shadow: var(--shadow-md);
+  overflow: visible;
+}
+
+/* address-search is now BELOW zip-filter → bottom radius */
+#address-search {
+  position: relative; /* required for suggestions dropdown */
+  display: flex;
+}
+
+#address-input {
+  flex: 1;
+  padding: 8px 12px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--dark);
+  border: none;
+  outline: none;
+  background: transparent;
+  border-radius: 0 0 0 8px;
+  min-width: 0;
+}
+
+#address-input::placeholder { color: #b0a9a0; }
+
+#address-clear {
+  background: transparent;
+  border: none;
+  padding: 0 6px;
+  cursor: pointer;
+  color: var(--gray-600);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+
+#address-clear:hover { color: var(--dark); }
+#address-clear svg { width: 14px; height: 14px; }
+
+#address-search-btn {
+  background: var(--blue);
+  border: none;
+  padding: 0 12px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 0 0 8px 0;
+  transition: background 0.15s;
+}
+
+#address-search-btn:hover { background: #0a3060; }
+#address-search-btn:disabled { opacity: 0.6; cursor: default; }
+
+#address-search-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke: #fff;
+}
+
+/* ── Address autocomplete dropdown ──────────────────── */
+#address-suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 4px;
+  background: var(--white);
+  border-radius: 6px;
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+  z-index: 1010;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.suggestion-item {
+  padding: 9px 12px;
+  font-size: 12px;
+  font-family: var(--font-body);
+  color: var(--dark);
+  cursor: pointer;
+  border-bottom: 1px solid var(--gray-100);
+  line-height: 1.4;
+}
+
+.suggestion-item:last-child { border-bottom: none; }
+
+.suggestion-item:hover,
+.suggestion-item.active {
+  background: var(--blue-pale);
+  color: var(--blue);
+}
+
+/* ── Controls panel (map layer + discrepancy, top-right) */
+#controls-panel {
+  position: absolute;
+  top: 10px;
+  right: 10px;
   z-index: 1000;
   background: var(--white);
   border-radius: 8px;
-  padding: 14px 16px;
   box-shadow: var(--shadow-md);
   font-size: 12px;
   font-family: var(--font-body);
+}
+
+/* ── Map layer control (inside controls-panel) ───────── */
+#map-layer-control {
+  padding: 12px 14px;
   border: none;
+  border-radius: 8px 8px 0 0;
 }
 
 #map-layer-control fieldset {
@@ -187,7 +277,7 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.8px;
   color: var(--gray-600);
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   float: none;
   width: 100%;
 }
@@ -198,14 +288,307 @@ body {
   gap: 8px;
   cursor: pointer;
   color: var(--dark);
-  padding: 4px 0;
+  padding: 3px 0;
 }
 
 #map-layer-control input[type="radio"] {
   accent-color: var(--blue);
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+}
+
+/* ── Zip row (inside search-panel, now on TOP) ───────── */
+#zip-filter {
+  display: flex;
+  border-bottom: 1px solid var(--border);
+}
+
+#zip-input {
+  flex: 1;
+  padding: 8px 10px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--dark);
+  border: none;
+  outline: none;
+  background: transparent;
+  min-width: 0;
+  border-radius: 8px 0 0 0;
+}
+
+#zip-input::placeholder { color: #b0a9a0; }
+
+#zip-clear {
+  background: transparent;
+  border: none;
+  padding: 0 6px;
+  cursor: pointer;
+  color: var(--gray-600);
+  font-size: 16px;
+  line-height: 1;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  transition: color 0.15s;
+}
+
+#zip-clear:hover { color: var(--dark); }
+
+#zip-browse-btn {
+  background: var(--gray-100);
+  border: none;
+  border-left: 1px solid var(--border);
+  padding: 0 10px;
+  cursor: pointer;
+  color: var(--gray-600);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 0 8px 0 0;
+  transition: background 0.15s, color 0.15s;
+}
+
+#zip-browse-btn:hover { background: var(--blue-pale); color: var(--blue); }
+#zip-browse-btn svg { width: 14px; height: 14px; }
+
+/* ── Zip selector panel ──────────────────────────────── */
+#zip-selector {
+  position: absolute;
+  top: 88px; /* below search panel */
+  left: 48px;
+  z-index: 1000;
+  width: 280px;
+  background: var(--white);
+  border-radius: 8px;
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.zip-selector-header {
+  padding: 9px 14px;
+  background: var(--blue);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-heading);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--white);
+}
+
+#zip-selector-close {
+  background: transparent;
+  border: none;
+  color: rgb(255 255 255 / 70%);
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 2px;
+}
+
+#zip-selector-close:hover { color: var(--white); }
+
+#zip-list {
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.zip-item {
+  padding: 8px 14px;
+  font-size: 12px;
+  font-family: var(--font-body);
+  cursor: pointer;
+  color: var(--dark);
+  border-bottom: 1px solid var(--gray-100);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.zip-item:last-child { border-bottom: none; }
+
+.zip-item:hover,
+.zip-item.hovered {
+  background: var(--blue-pale);
+  color: var(--blue);
+  font-weight: 600;
+}
+
+/* ── Discrepancy filter (inside controls-panel) ─────── */
+#discrepancy-filter {
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  border-radius: 0 0 8px 8px;
+  min-width: 160px;
+}
+
+.filter-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  cursor: pointer;
+  font-weight: 600;
+  color: var(--dark);
+}
+
+.filter-toggle-label input[type="checkbox"] {
+  accent-color: var(--blue);
   width: 14px;
   height: 14px;
+}
+
+.filter-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--gray-600);
+}
+
+.filter-row strong {
+  color: var(--blue);
+  font-size: 12px;
+}
+
+#threshold-slider {
+  width: 100%;
+  margin-top: 4px;
+  accent-color: var(--blue);
+}
+
+/* ── Hover tooltip (follows cursor) ────────────────── */
+#hover-tooltip {
+  position: absolute;
+  z-index: 1001;
+  pointer-events: none;
+  background: rgb(15 15 15 / 88%);
+  color: #fff;
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+  min-width: 160px;
+  max-width: 240px;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 30%);
+}
+
+.tooltip-address {
+  margin: 0 0 5px;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tooltip-dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  font-size: 11px;
+}
+
+.tooltip-dl dt { color: rgb(255 255 255 / 65%); white-space: nowrap; }
+.tooltip-dl dd { margin: 0; font-weight: 500; }
+
+/* ── MapLibre popup (shown near clicked property) ────── */
+.map-popup .maplibregl-popup-content {
+  border-left: 4px solid var(--blue);
+  border-radius: 6px;
+  padding: 12px 16px 12px 14px;
+  box-shadow: var(--shadow-md);
+  font-family: var(--font-body);
+  font-size: 13px;
+  min-width: 220px;
+  max-width: 280px;
+}
+
+.map-popup .maplibregl-popup-close-button {
+  font-size: 20px;
+  color: var(--gray-600);
+  padding: 2px 8px;
+  line-height: 1;
+}
+
+.map-popup .maplibregl-popup-close-button:hover {
+  background: var(--gray-100);
+  border-radius: 4px;
+}
+
+.map-popup.maplibregl-popup-anchor-top .maplibregl-popup-tip {
+  border-bottom-color: var(--white);
+}
+
+.popup-address {
+  margin: 0 20px 10px 0;
+  font-family: var(--font-heading);
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--blue);
+  line-height: 1.3;
+}
+
+.popup-details {
+  margin: 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 5px 12px;
+}
+
+.popup-details dt { color: var(--gray-600); white-space: nowrap; font-size: 12px; }
+.popup-details dd { margin: 0; font-weight: 600; font-size: 12px; }
+.change-pos { color: #31a354; }
+.change-neg { color: #d73027; }
+
+/* ── Legend box (bottom-right of map, vertical) ─────── */
+#legend-box {
+  position: absolute;
+  bottom: 44px; /* above MapLibre attribution */
+  right: 10px;
+  z-index: 1000;
+  background: rgb(255 255 255 / 96%);
+  border-radius: 8px;
+  padding: 12px 14px;
+  box-shadow: var(--shadow-md);
+  backdrop-filter: blur(4px);
+}
+
+.legend-note {
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--dark);
+  font-style: normal;
+  margin: 0 0 10px;
+  white-space: nowrap;
+}
+
+.legend-body {
+  display: flex;
+  gap: 8px;
+  align-items: stretch;
+}
+
+.legend-ramp {
+  width: 16px;
+  height: 130px;
   flex-shrink: 0;
+  border-radius: 4px;
+  background: linear-gradient(to bottom, #006d2c, #31a354, #74c476, #c7e9c0, #f7fcf5);
+  border: 1px solid rgb(0 0 0 / 8%);
+}
+
+.legend-labels {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--gray-600);
 }
 
 /* ── Zoom hint ──────────────────────────────────────── */
@@ -217,7 +600,6 @@ body {
   background: rgb(15 77 144 / 85%);
   color: #fff;
   font-size: 12px;
-  font-family: var(--font-body);
   padding: 8px 16px;
   border-radius: 100px;
   pointer-events: none;
@@ -225,55 +607,13 @@ body {
   display: none;
 }
 
-/* ── Property popup ─────────────────────────────────── */
-#property-popup {
-  position: absolute;
-  bottom: 16px;
-  left: 16px;
-  background: var(--white);
-  border-left: 4px solid var(--blue);
-  border-radius: 6px;
-  padding: 14px 18px;
-  font-size: 13px;
-  max-width: 280px;
-  box-shadow: var(--shadow-md);
-  z-index: 1000;
-}
-
-.popup-address {
-  margin: 0 0 8px;
-  font-family: var(--font-heading);
-  font-weight: 600;
-  font-size: 13px;
-  color: var(--blue);
-}
-
-.popup-details {
-  margin: 0;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 4px 14px;
-}
-
-.popup-details dt {
-  color: var(--gray-600);
-  white-space: nowrap;
-}
-
-.popup-details dd {
-  margin: 0;
-  font-weight: 500;
-}
-
 /* ── Info panel ─────────────────────────────────────── */
 #info-panel {
   grid-area: info;
   background: var(--white);
-  padding: 20px 22px;
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 0;
 }
 
 #info-panel h2 {
@@ -284,110 +624,123 @@ body {
   letter-spacing: 1.2px;
   color: var(--white);
   background: var(--blue);
-  margin: 0 -22px 14px;
-  padding: 7px 22px;
+  margin: 0;
+  padding: 8px 20px;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
 }
 
-#info-panel section {
-  padding-bottom: 20px;
+.h2-year {
+  background: rgb(255 255 255 / 20%);
+  border-radius: 100px;
+  padding: 1px 8px;
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0;
+  text-transform: none;
 }
 
-#info-panel section + section {
-  border-top: 1px solid var(--border);
-  padding-top: 20px;
+/* ── Summary stat cards ─────────────────────────────── */
+#summary-section {
+  padding-bottom: 16px;
+  flex-shrink: 0;
 }
 
-/* ── Legend ─────────────────────────────────────────── */
-.legend-ramp {
-  height: 14px;
-  border-radius: 4px;
-  background: linear-gradient(to right, #f7fcf5, #c7e9c0, #74c476, #31a354, #006d2c, #00441b);
-  margin-bottom: 6px;
-  border: 1px solid rgb(0 0 0 / 8%);
-}
-
-.legend-labels {
-  display: flex;
-  justify-content: space-between;
-  font-size: 10px;
-  color: var(--gray-600);
-  margin-bottom: 6px;
-}
-
-.legend-note {
-  font-size: 11px;
-  color: var(--gray-600);
-  font-style: italic;
-  margin: 0;
-}
-
-/* ── Summary text ───────────────────────────────────── */
-#summary-text {
-  font-size: 13px;
-  line-height: 1.9;
-  margin: 0;
-  color: var(--gray-600);
-}
-
-/* ── Selected property ──────────────────────────────── */
-.no-selection-hint {
-  font-size: 13px;
-  color: var(--gray-600);
-  font-style: italic;
-  margin: 0;
-}
-
-#property-detail-list {
-  margin: 0;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 10px;
-  font-size: 13px;
-}
-
-#property-detail-list dt {
-  color: var(--gray-600);
-  font-size: 11px;
-  margin-bottom: 1px;
-}
-
-#property-detail-list dd {
-  margin: 0;
-  font-weight: 600;
-  color: var(--dark);
-}
-
-/* ── Charts section ─────────────────────────────────── */
-#charts-section {
-  grid-area: charts;
-  background: var(--white);
-  padding: 20px 24px;
+.stat-cards {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  border-top: 3px solid var(--blue);
+  gap: 8px;
+  padding: 12px 16px 0;
+}
+
+.stat-card {
+  background: var(--blue-pale);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* ── Year selector ──────────────────────────────────── */
+.year-selector {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.year-btn {
+  padding: 3px 10px;
+  font-family: var(--font-heading);
+  font-size: 10px;
+  font-weight: 600;
+  border: 1.5px solid var(--gray-300);
+  border-radius: 100px;
+  background: transparent;
+  color: var(--gray-600);
+  cursor: pointer;
+  transition: all 0.12s;
+}
+
+.year-btn:hover {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.year-btn.active {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: var(--white);
+}
+
+.stat-card-value {
+  font-family: var(--font-heading);
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--blue);
+  line-height: 1;
+}
+
+.stat-card-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--gray-600);
+  font-weight: 600;
+}
+
+/* ── Charts section (in info panel) ────────────────── */
+#charts-section {
+  flex: 1;
+  border-top: 1px solid var(--border);
+  padding: 0 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.chart-container {
+  padding: 14px 16px 0;
 }
 
 .chart-container h3 {
   font-family: var(--font-heading);
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
   color: var(--dark);
-  margin: 0 0 4px;
+  margin: 0 0 3px;
 }
 
 .chart-subtitle {
-  font-size: 11px;
+  font-size: 10px;
   color: var(--gray-600);
-  margin: 0 0 12px;
+  margin: 0 0 8px;
 }
 
-/* ── Chart placeholder ──────────────────────────────── */
 .chart {
-  height: 160px;
+  height: 150px;
   background: var(--gray-100);
   border: 1px dashed var(--gray-300);
   border-radius: 6px;
@@ -395,13 +748,11 @@ body {
   align-items: center;
   justify-content: center;
   color: #b0a9a0;
-  font-size: 12px;
+  font-size: 11px;
   font-style: italic;
 }
 
-.chart::before {
-  content: "Loading data…";
-}
+.chart::before { content: "Loading data…"; }
 
 .chart.chart-loaded {
   display: block;
@@ -410,6 +761,20 @@ body {
   border: none;
 }
 
-.chart.chart-loaded::before {
-  display: none;
+.chart.chart-loaded::before { display: none; }
+
+/* ── Popup "View full history" link ─────────────────── */
+.popup-link {
+  display: inline-block;
+  margin-top: 10px;
+  font-family: var(--font-heading);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--blue-mid);
+  text-decoration: none;
+}
+
+.popup-link:hover {
+  color: var(--blue);
+  text-decoration: underline;
 }

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -46,7 +46,7 @@
         </h2>
         <form id="lookup-form">
           <label for="address-input" class="field-label">Property Address</label>
-          <div class="input-row input-row--suggest">
+          <div class="input-row input-row-suggest">
             <input
               type="text"
               id="address-input"

--- a/ui/widget/index.html
+++ b/ui/widget/index.html
@@ -45,16 +45,18 @@
           Look up a property
         </h2>
         <form id="lookup-form">
-          <label for="opa-id-input" class="field-label">OPA Parcel Number</label>
-          <div class="input-row">
+          <label for="address-input" class="field-label">Property Address</label>
+          <div class="input-row input-row--suggest">
             <input
               type="text"
-              id="opa-id-input"
-              name="opa-id"
-              placeholder="e.g. 883309050"
-              inputmode="numeric"
-              pattern="[0-9]{9,10}"
+              id="address-input"
+              name="address"
+              placeholder="e.g. 1234 Market St"
               autocomplete="off"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-expanded="false"
+              aria-controls="address-suggestions"
             >
             <button type="submit" class="btn-primary">
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -62,8 +64,9 @@
                 <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
               </svg>
             </button>
+            <div id="address-suggestions" role="listbox" hidden></div>
           </div>
-          <p class="field-hint">Enter the 9 or 10-digit OPA parcel number</p>
+          <p class="field-hint">Start typing a Philadelphia address</p>
         </form>
         <p id="lookup-status" class="lookup-status" role="status" aria-live="polite"></p>
       </section>
@@ -85,9 +88,11 @@
           <p id="property-city-zip" class="property-city-zip">—</p>
           <dl class="property-meta">
             <dt>OPA ID</dt><dd id="meta-opa-id">—</dd>
-            <dt>Tax balance</dt><dd id="meta-tax-balance">—</dd>
+            <dt>Owner</dt><dd id="meta-owner">—</dd>
+            <dt>Current value</dt><dd id="meta-market-value">—</dd>
             <dt>Records</dt><dd id="meta-record-count">—</dd>
           </dl>
+          <div id="property-chars" hidden></div>
         </div>
       </section>
 
@@ -95,8 +100,14 @@
 
     <section id="chart-section">
       <h3>Assessment value over time</h3>
-      <p class="section-subtitle">Market value by tax year</p>
+      <p class="section-subtitle">Market value by tax year · years with &gt;10% change are labeled</p>
       <div id="valuation-chart" class="chart"></div>
+    </section>
+
+    <section id="breakdown-section">
+      <h3>Value breakdown</h3>
+      <p class="section-subtitle">Taxable land vs. building by tax year</p>
+      <div id="breakdown-chart" class="chart breakdown-placeholder"></div>
     </section>
 
     <section id="table-section">

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -39,7 +39,7 @@ const setStatus = (msg, isError = false) => {
 
 const debounce = (fn, delay) => {
   let timer;
-  return (...args) => { clearTimeout(timer); timer = setTimeout(() => fn(...args), delay); };
+  return (...args) => { clearTimeout(timer); timer = setTimeout(() => fn(...args), delay) };
 };
 
 const fetchSuggestions = async (query) => {

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -1,10 +1,10 @@
-// widget main script — OPA ID lookup + assessment history chart and table
+// widget main script — address lookup + assessment history chart and table
 
 /* global ApexCharts */
 
-// Philadelphia Open Data (Socrata) endpoints
-const opaPropertiesUrl = 'https://data.phila.gov/resource/qqem-6pc7.json';
-const opaAssessmentsUrl = 'https://data.phila.gov/resource/w7rb-qrpr.json';
+// Our own Cloud Run Function backed by core.opa_properties + core.opa_assessments
+const propertyLookupUrl =
+  'https://us-east4-musa5090s26-team6.cloudfunctions.net/property-lookup';
 
 const currencyFmt = new Intl.NumberFormat('en-US', {
   style: 'currency',
@@ -18,39 +18,267 @@ const formatCurrency = (val) => {
   return currencyFmt.format(num);
 };
 
-let valuationChart = null;
-
-const setStatus = (msg) => {
-  document.getElementById('lookup-status').textContent = msg;
+const CATEGORY_LABELS = {
+  '1': 'Single Family',
+  '2': 'Multi Family',
+  '8': 'Residential Garage',
+  '13': 'Vacant Land (Res.)',
+  '14': 'Apartment 5+ Units',
 };
 
-const updatePropertyInfo = (prop, opaId, assessData) => {
+let valuationChart = null;
+let breakdownChart = null;
+
+const setStatus = (msg, isError = false) => {
+  const el = document.getElementById('lookup-status');
+  el.textContent = msg;
+  el.style.color = isError ? '#d73027' : '';
+};
+
+// ── Photon autocomplete ──────────────────────────────
+
+const debounce = (fn, delay) => {
+  let timer;
+  return (...args) => { clearTimeout(timer); timer = setTimeout(() => fn(...args), delay); };
+};
+
+const fetchSuggestions = async (query) => {
+  if (query.length < 3) return [];
+  try {
+    const url = new URL('https://photon.komoot.io/api/');
+    url.searchParams.set('q', `${query} Philadelphia`);
+    url.searchParams.set('limit', '6');
+    url.searchParams.set('bbox', '-75.2803,39.8676,-74.9558,40.1379');
+    url.searchParams.set('lang', 'en');
+    const res = await fetch(url.toString());
+    const data = await res.json();
+
+    // Extract leading house number from what the user typed (e.g. "2201" from "2201 PARK TOWNE PL")
+    // Used as fallback when Photon doesn't return a housenumber for a result
+    const queryHouseNum = (/^\d+/.exec(query.trim()) || [])[0] || '';
+
+    const seen = new Set();
+    return data.features.map((f) => {
+      const p = f.properties;
+      const houseNum = p['housenumber'] || queryHouseNum;
+      const streetName = p['street'] || p['name'] || '';
+
+      const parts = [];
+      if (houseNum) parts.push(houseNum);
+      if (streetName) parts.push(streetName);
+      if (p['city']) parts.push(p['city']);
+      if (p['postcode']) parts.push(p['postcode']);
+
+      const addressSearch = [
+        houseNum,
+        streetName.split(' ')[0],
+      ].filter(Boolean).join(' ').toUpperCase();
+
+      return { label: parts.join(', '), addressSearch };
+    })
+      .filter((s) => s.label && s.addressSearch)
+      .filter((s) => {                          // deduplicate by addressSearch
+        if (seen.has(s.addressSearch)) return false;
+        seen.add(s.addressSearch);
+        return true;
+      });
+  } catch {
+    return [];
+  }
+};
+
+// ── Our own pipeline API (core.opa_properties + core.opa_assessments) ────────
+
+const findPropertyByAddress = async (searchStr) => {
+  const url = new URL(propertyLookupUrl);
+  url.searchParams.set('search', searchStr);
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  const data = await res.json();
+  // Returns array; pick the first match
+  return data[0] || null;
+};
+
+const fetchPropertyAndAssessments = async (parcelNumber) => {
+  const url = new URL(propertyLookupUrl);
+  url.searchParams.set('parcel_number', parcelNumber);
+  const res = await fetch(url.toString());
+  if (res.status === 404) throw Object.assign(new Error('Not found'), { notFound: true });
+  if (!res.ok) throw new Error(`API error: ${res.status}`);
+  return res.json(); // { property, assessments }
+};
+
+const updatePropertyInfo = (prop, assessData) => {
   document.getElementById('property-empty').hidden = true;
   document.getElementById('property-loaded').removeAttribute('hidden');
-  document.getElementById('property-address').textContent =
-    prop['location'] || prop['street_address'] || '—';
+  document.getElementById('property-address').textContent = prop['location'] || '—';
   document.getElementById('property-city-zip').textContent = 'Philadelphia, PA';
-  document.getElementById('meta-opa-id').textContent = opaId;
-  document.getElementById('meta-tax-balance').textContent = '—';
+  document.getElementById('meta-opa-id').textContent = prop['property_id'] || prop['parcel_number'] || '—';
+  document.getElementById('meta-owner').textContent = prop['owner_1'] || '—';
+  document.getElementById('meta-market-value').textContent = formatCurrency(prop['market_value']);
   document.getElementById('meta-record-count').textContent =
     `${assessData.length} year${assessData.length !== 1 ? 's' : ''}`;
+  renderCharacteristics(prop);
+};
+
+const showPropertyError = (msg) => {
+  document.getElementById('property-empty').hidden = true;
+  document.getElementById('property-loaded').removeAttribute('hidden');
+  document.getElementById('property-address').textContent = msg;
+  document.getElementById('property-city-zip').textContent = '';
+  document.getElementById('meta-opa-id').textContent = '—';
+  document.getElementById('meta-owner').textContent = '—';
+  document.getElementById('meta-market-value').textContent = '—';
+  document.getElementById('meta-record-count').textContent = '—';
+  document.getElementById('property-chars').hidden = true;
+};
+
+const renderCharacteristics = (prop) => {
+  const el = document.getElementById('property-chars');
+  if (!el) return;
+
+  const area = Number(prop['total_livable_area']) || 0;
+  const value = Number(prop['market_value']) || 0;
+  const perSqft = area > 0 ? Math.round(value / area) : null;
+  const yearBuilt = prop['year_built'];
+  const typeLabel = CATEGORY_LABELS[prop['category_code']] || `Category ${prop['category_code']}`;
+  const beds = prop['number_of_bedrooms'];
+  const baths = prop['number_of_bathrooms'] != null ? Number(prop['number_of_bathrooms']) : null;
+
+  const items = [
+    yearBuilt != null ? { value: yearBuilt, label: 'Year Built' } : null,
+    area > 0 ? { value: `${Math.round(area).toLocaleString()} sq ft`, label: 'Living Area' } : null,
+    { value: typeLabel, label: 'Property Type' },
+    perSqft != null ? { value: `$${perSqft.toLocaleString()} / sq ft`, label: 'Value per sq ft' } : null,
+    beds != null ? { value: beds, label: 'Bedrooms' } : null,
+    baths != null ? { value: baths, label: 'Bathrooms' } : null,
+  ].filter(Boolean);
+
+  if (items.length === 0) { el.hidden = true; return; }
+
+  el.innerHTML = `
+    <p class="chars-section-label">Property characteristics</p>
+    <div class="chars-grid">
+      ${items.map((item) => `
+        <div class="char-item">
+          <span class="char-item-value">${item.value}</span>
+          <span class="char-item-label">${item.label}</span>
+        </div>`).join('')}
+    </div>`;
+  el.removeAttribute('hidden');
+};
+
+const renderBreakdownChart = (assessData) => {
+  const el = document.getElementById('breakdown-chart');
+  if (!el || assessData.length === 0) return;
+
+  const years = assessData.map((d) => d['year']);
+  const taxLand = assessData.map((d) => Number(d['taxable_land']) || 0);
+  const taxBuilding = assessData.map((d) => Number(d['taxable_building']) || 0);
+  const exempt = assessData.map(
+    (d) => (Number(d['exempt_land']) || 0) + (Number(d['exempt_building']) || 0),
+  );
+  const hasExempt = exempt.some((v) => v > 0);
+
+  const series = [
+    { name: 'Taxable Land', data: taxLand },
+    { name: 'Taxable Building', data: taxBuilding },
+    ...(hasExempt ? [{ name: 'Exempt', data: exempt }] : []),
+  ];
+
+  el.classList.add('chart-loaded');
+
+  if (breakdownChart) {
+    breakdownChart.updateSeries(series);
+    breakdownChart.updateOptions({ xaxis: { categories: years } });
+    return;
+  }
+
+  breakdownChart = new ApexCharts(el, {
+    chart: {
+      type: 'bar',
+      stacked: true,
+      height: 200,
+      toolbar: { show: false },
+      animations: { enabled: false },
+      fontFamily: '"Open Sans", system-ui, sans-serif',
+    },
+    series,
+    xaxis: {
+      categories: years,
+      labels: { style: { fontSize: '10px', colors: '#6d6d6d' } },
+      axisBorder: { show: false },
+      axisTicks: { show: false },
+    },
+    yaxis: {
+      labels: {
+        style: { colors: '#6d6d6d', fontSize: '10px' },
+        formatter: (v) => {
+          if (v >= 1000000) return `$${(v / 1000000).toFixed(1)}M`;
+          if (v >= 1000) return `$${(v / 1000).toFixed(0)}k`;
+          return `$${v}`;
+        },
+      },
+    },
+    colors: ['#0f4d90', '#2176d2', '#d4d1c8'],
+    dataLabels: { enabled: false },
+    tooltip: { y: { formatter: (v) => currencyFmt.format(v) }, theme: 'light' },
+    legend: {
+      position: 'bottom',
+      fontSize: '11px',
+      fontFamily: '"Open Sans", system-ui, sans-serif',
+      markers: { width: 10, height: 10, radius: 2 },
+      itemMargin: { horizontal: 8 },
+    },
+    grid: { borderColor: '#f0ede5', strokeDashArray: 4 },
+    plotOptions: { bar: { columnWidth: '80%' } },
+  });
+  breakdownChart.render();
 };
 
 const renderValuationChart = (assessData) => {
   const el = document.getElementById('valuation-chart');
   el.classList.add('chart-loaded');
 
-  const years = assessData.map((d) => d['tax_year'] || d['year']);
+  const years = assessData.map((d) => d['year']);
   const values = assessData.map((d) => Number(d['market_value']) || 0);
+
+  // Annotate years where value changed >10% from previous year
+  const changeAnnotations = years.map((year, i) => {
+    if (i === 0) return null;
+    const prev = values[i - 1];
+    const curr = values[i];
+    if (!prev || !curr) return null;
+    const pct = (curr - prev) / prev * 100;
+    if (Math.abs(pct) < 10) return null;
+    return {
+      x: year,
+      y: curr,
+      marker: { size: 0 },
+      label: {
+        borderColor: 'transparent',
+        offsetY: -10,
+        text: `${pct > 0 ? '+' : ''}${Math.round(pct)}%`,
+        style: {
+          background: 'transparent',
+          color: pct > 0 ? '#31a354' : '#d73027',
+          fontSize: '9px',
+          fontWeight: '700',
+          padding: { top: 0, bottom: 0, left: 2, right: 2 },
+        },
+      },
+    };
+  }).filter(Boolean);
 
   const options = {
     chart: {
       type: 'area',
-      height: 280,
+      height: 260,
       toolbar: { show: false },
       animations: { enabled: false },
       fontFamily: '"Open Sans", system-ui, sans-serif',
     },
+    annotations: { points: changeAnnotations },
     series: [{ name: 'Market value', data: values }],
     xaxis: {
       categories: years,
@@ -95,7 +323,10 @@ const renderValuationChart = (assessData) => {
 
   if (valuationChart) {
     valuationChart.updateSeries([{ name: 'Market value', data: values }]);
-    valuationChart.updateOptions({ xaxis: { categories: years } });
+    valuationChart.updateOptions({
+      xaxis: { categories: years },
+      annotations: { points: changeAnnotations },
+    });
   } else {
     valuationChart = new ApexCharts(el, options);
     valuationChart.render();
@@ -112,59 +343,145 @@ const populateValuationTable = (assessData) => {
 
   tbody.innerHTML = assessData.map((d) => [
     '<tr>',
-    `<td>${d['tax_year'] || d['year'] || '—'}</td>`,
+    `<td>${d['year'] || '—'}</td>`,
     `<td>${formatCurrency(d['market_value'])}</td>`,
     `<td>${formatCurrency(d['taxable_land'])}</td>`,
-    `<td>${formatCurrency(d['taxable_improvement'])}</td>`,
+    `<td>${formatCurrency(d['taxable_building'])}</td>`,
     `<td>${formatCurrency(d['exempt_land'])}</td>`,
     `<td>${formatCurrency(d['exempt_building'])}</td>`,
     '</tr>',
   ].join('')).join('');
 };
 
-const loadProperty = async (opaId) => {
-  setStatus('Loading…');
-
+const loadProperty = async (searchStr) => {
+  setStatus('Searching…');
   try {
-    const [propRes, assessRes] = await Promise.all([
-      fetch(`${opaPropertiesUrl}?parcel_number=${encodeURIComponent(opaId)}&$limit=1`),
-      fetch(`${opaAssessmentsUrl}?parcel_number=${encodeURIComponent(opaId)}&$order=tax_year%20ASC&$limit=50`),
-    ]);
-
-    if (!propRes.ok || !assessRes.ok) {
-      throw new Error(`API error: ${propRes.status} / ${assessRes.status}`);
-    }
-
-    const [propData, assessData] = await Promise.all([propRes.json(), assessRes.json()]);
-
-    if (propData.length === 0) {
-      setStatus('No property found for that OPA ID. Please check the number and try again.');
+    // Step 1: find property by address → get property_id
+    const match = await findPropertyByAddress(searchStr);
+    if (!match) {
+      setStatus('No property found. Try a more specific address.', true);
       return;
     }
 
+    // Step 2: fetch full property info + assessment history
+    const { property, assessments } = await fetchPropertyAndAssessments(match['property_id']);
+
     setStatus('');
-    updatePropertyInfo(propData[0], opaId, assessData);
-    renderValuationChart(assessData);
-    populateValuationTable(assessData);
+    updatePropertyInfo(property, assessments);
+    renderValuationChart(assessments);
+    renderBreakdownChart(assessments);
+    populateValuationTable(assessments);
   } catch (err) {
     console.error('Property lookup failed:', err);
-    setStatus('Failed to load property data. Please try again.');
+    setStatus('Failed to load property data. Please try again.', true);
+  }
+};
+
+// Load directly by parcel number (used when linked from reviewer map)
+const loadPropertyById = async (parcelNumber) => {
+  setStatus('Loading…');
+  try {
+    const { property, assessments } = await fetchPropertyAndAssessments(String(parcelNumber));
+    setStatus('');
+    updatePropertyInfo(property, assessments);
+    renderValuationChart(assessments);
+    renderBreakdownChart(assessments);
+    populateValuationTable(assessments);
+  } catch (err) {
+    console.error('Property lookup failed:', err);
+    if (err.notFound) {
+      showPropertyError('Property not found in database.');
+      setStatus('');
+    } else {
+      setStatus('Failed to load property data. Please try again.', true);
+    }
   }
 };
 
 document.addEventListener('DOMContentLoaded', () => {
   const lookupForm = document.getElementById('lookup-form');
-  const opaIdInput = document.getElementById('opa-id-input');
+  const addressInput = document.getElementById('address-input');
+  const suggestionsEl = document.getElementById('address-suggestions');
+
+  let activeSuggestions = [];
+  let activeIndex = -1;
+
+  const renderSuggestions = (suggestions) => {
+    activeSuggestions = suggestions;
+    activeIndex = -1;
+    suggestionsEl.innerHTML = '';
+    if (suggestions.length === 0) {
+      suggestionsEl.hidden = true;
+      addressInput.setAttribute('aria-expanded', 'false');
+      return;
+    }
+    suggestions.forEach((s) => {
+      const item = document.createElement('div');
+      item.className = 'suggestion-item';
+      item.setAttribute('role', 'option');
+      item.textContent = s.label;
+      item.addEventListener('mousedown', (e) => {
+        e.preventDefault();
+        addressInput.value = s.label;
+        suggestionsEl.hidden = true;
+        addressInput.setAttribute('aria-expanded', 'false');
+        loadProperty(s.addressSearch);
+      });
+      suggestionsEl.appendChild(item);
+    });
+    suggestionsEl.hidden = false;
+    addressInput.setAttribute('aria-expanded', 'true');
+  };
+
+  const debouncedFetch = debounce(async (query) => {
+    renderSuggestions(await fetchSuggestions(query));
+  }, 280);
+
+  addressInput.addEventListener('input', () => {
+    const q = addressInput.value.trim();
+    if (q.length >= 3) debouncedFetch(q);
+    else suggestionsEl.hidden = true;
+  });
+
+  addressInput.addEventListener('keydown', (e) => {
+    const items = suggestionsEl.querySelectorAll('.suggestion-item');
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      activeIndex = Math.min(activeIndex + 1, items.length - 1);
+      items.forEach((el, i) => el.classList.toggle('active', i === activeIndex));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      activeIndex = Math.max(activeIndex - 1, -1);
+      items.forEach((el, i) => el.classList.toggle('active', i === activeIndex));
+    } else if (e.key === 'Escape') {
+      suggestionsEl.hidden = true;
+      addressInput.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  addressInput.addEventListener('blur', () => {
+    setTimeout(() => {
+      suggestionsEl.hidden = true;
+      addressInput.setAttribute('aria-expanded', 'false');
+    }, 150);
+  });
 
   lookupForm.addEventListener('submit', (e) => {
     e.preventDefault();
-    const opaId = opaIdInput.value.trim();
-
-    if (!/^\d{9,10}$/.test(opaId)) {
-      setStatus('Please enter a valid OPA ID (9 or 10 digits, numbers only).');
-      return;
+    suggestionsEl.hidden = true;
+    let search;
+    if (activeIndex >= 0 && activeSuggestions[activeIndex]) {
+      search = activeSuggestions[activeIndex].addressSearch;
+    } else if (activeSuggestions.length > 0) {
+      search = activeSuggestions[0].addressSearch;
+    } else {
+      search = addressInput.value.trim().split(' ').slice(0, 2).join(' ').toUpperCase();
     }
-
-    loadProperty(opaId);
+    if (search) loadProperty(search);
   });
+
+  // Auto-load from URL param when linked from reviewer map popup
+  const params = new URLSearchParams(window.location.search);
+  const parcelParam = params.get('parcel_number');
+  if (parcelParam) loadPropertyById(parcelParam);
 });

--- a/ui/widget/main.js
+++ b/ui/widget/main.js
@@ -108,6 +108,41 @@ const fetchPropertyAndAssessments = async (parcelNumber) => {
   return res.json(); // { property, assessments }
 };
 
+const renderCharacteristics = (prop) => {
+  const el = document.getElementById('property-chars');
+  if (!el) return;
+
+  const area = Number(prop['total_livable_area']) || 0;
+  const value = Number(prop['market_value']) || 0;
+  const perSqft = area > 0 ? Math.round(value / area) : null;
+  const yearBuilt = prop['year_built'];
+  const typeLabel = CATEGORY_LABELS[prop['category_code']] || `Category ${prop['category_code']}`;
+  const beds = prop['number_of_bedrooms'];
+  const baths = prop['number_of_bathrooms'] != null ? Number(prop['number_of_bathrooms']) : null;
+
+  const items = [
+    yearBuilt != null ? { value: yearBuilt, label: 'Year Built' } : null,
+    area > 0 ? { value: `${Math.round(area).toLocaleString()} sq ft`, label: 'Living Area' } : null,
+    { value: typeLabel, label: 'Property Type' },
+    perSqft != null ? { value: `$${perSqft.toLocaleString()} / sq ft`, label: 'Value per sq ft' } : null,
+    beds != null ? { value: beds, label: 'Bedrooms' } : null,
+    baths != null ? { value: baths, label: 'Bathrooms' } : null,
+  ].filter(Boolean);
+
+  if (items.length === 0) { el.hidden = true; return }
+
+  el.innerHTML = `
+    <p class="chars-section-label">Property characteristics</p>
+    <div class="chars-grid">
+      ${items.map((item) => `
+        <div class="char-item">
+          <span class="char-item-value">${item.value}</span>
+          <span class="char-item-label">${item.label}</span>
+        </div>`).join('')}
+    </div>`;
+  el.removeAttribute('hidden');
+};
+
 const updatePropertyInfo = (prop, assessData) => {
   document.getElementById('property-empty').hidden = true;
   document.getElementById('property-loaded').removeAttribute('hidden');
@@ -131,41 +166,6 @@ const showPropertyError = (msg) => {
   document.getElementById('meta-market-value').textContent = '—';
   document.getElementById('meta-record-count').textContent = '—';
   document.getElementById('property-chars').hidden = true;
-};
-
-const renderCharacteristics = (prop) => {
-  const el = document.getElementById('property-chars');
-  if (!el) return;
-
-  const area = Number(prop['total_livable_area']) || 0;
-  const value = Number(prop['market_value']) || 0;
-  const perSqft = area > 0 ? Math.round(value / area) : null;
-  const yearBuilt = prop['year_built'];
-  const typeLabel = CATEGORY_LABELS[prop['category_code']] || `Category ${prop['category_code']}`;
-  const beds = prop['number_of_bedrooms'];
-  const baths = prop['number_of_bathrooms'] != null ? Number(prop['number_of_bathrooms']) : null;
-
-  const items = [
-    yearBuilt != null ? { value: yearBuilt, label: 'Year Built' } : null,
-    area > 0 ? { value: `${Math.round(area).toLocaleString()} sq ft`, label: 'Living Area' } : null,
-    { value: typeLabel, label: 'Property Type' },
-    perSqft != null ? { value: `$${perSqft.toLocaleString()} / sq ft`, label: 'Value per sq ft' } : null,
-    beds != null ? { value: beds, label: 'Bedrooms' } : null,
-    baths != null ? { value: baths, label: 'Bathrooms' } : null,
-  ].filter(Boolean);
-
-  if (items.length === 0) { el.hidden = true; return; }
-
-  el.innerHTML = `
-    <p class="chars-section-label">Property characteristics</p>
-    <div class="chars-grid">
-      ${items.map((item) => `
-        <div class="char-item">
-          <span class="char-item-value">${item.value}</span>
-          <span class="char-item-label">${item.label}</span>
-        </div>`).join('')}
-    </div>`;
-  el.removeAttribute('hidden');
 };
 
 const renderBreakdownChart = (assessData) => {

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -146,6 +146,13 @@ body {
   padding: 2px;
 }
 
+.btn-primary svg {
+  width: 16px;
+  height: 16px;
+  stroke: #fff;
+  flex-shrink: 0;
+}
+
 /* ── Info panel ─────────────────────────────────────── */
 #info-panel {
   grid-area: info;
@@ -201,7 +208,7 @@ body {
   margin-bottom: 6px;
 }
 
-.input-row--suggest {
+.input-row-suggest {
   position: relative;
   flex-wrap: wrap;
 }
@@ -278,13 +285,6 @@ body {
 
 .btn-primary:hover {
   background: #0a3060;
-}
-
-.btn-primary svg {
-  width: 16px;
-  height: 16px;
-  stroke: #fff;
-  flex-shrink: 0;
 }
 
 .field-hint {

--- a/ui/widget/style.css
+++ b/ui/widget/style.css
@@ -132,21 +132,14 @@ body {
   letter-spacing: 0.2px;
 }
 
-/* ── Button SVG icon (declared before #info-panel h2 svg to satisfy specificity order) ── */
-.btn-primary svg {
-  width: 16px;
-  height: 16px;
-  stroke: #fff;
-  flex-shrink: 0;
-}
-
 /* ── Main grid ──────────────────────────────────────── */
 #widget-main {
   flex: 1;
   display: grid;
   grid-template:
-    "info chart" minmax(340px, auto)
-    "info table" 1fr
+    "info chart"     minmax(300px, auto)
+    "info breakdown" minmax(260px, auto)
+    "info table"     1fr
     / 1fr 2fr;
   gap: 2px;
   background: var(--border);
@@ -208,7 +201,45 @@ body {
   margin-bottom: 6px;
 }
 
-#opa-id-input {
+.input-row--suggest {
+  position: relative;
+  flex-wrap: wrap;
+}
+
+#address-suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  margin-top: 4px;
+  background: var(--white);
+  border-radius: 6px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 14%);
+  overflow: hidden;
+  z-index: 100;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.suggestion-item {
+  padding: 9px 12px;
+  font-size: 12px;
+  font-family: var(--font-body);
+  color: var(--dark);
+  cursor: pointer;
+  border-bottom: 1px solid var(--gray-100);
+  line-height: 1.4;
+}
+
+.suggestion-item:last-child { border-bottom: none; }
+
+.suggestion-item:hover,
+.suggestion-item.active {
+  background: var(--blue-pale);
+  color: var(--blue);
+}
+
+#address-input {
   flex: 1;
   padding: 10px 12px;
   font-family: var(--font-body);
@@ -221,11 +252,11 @@ body {
   min-width: 0;
 }
 
-#opa-id-input::placeholder {
+#address-input::placeholder {
   color: #b0a9a0;
 }
 
-#opa-id-input:focus {
+#address-input:focus {
   outline: none;
   border-color: var(--blue);
   box-shadow: 0 0 0 3px var(--blue-pale);
@@ -247,6 +278,13 @@ body {
 
 .btn-primary:hover {
   background: #0a3060;
+}
+
+.btn-primary svg {
+  width: 16px;
+  height: 16px;
+  stroke: #fff;
+  flex-shrink: 0;
 }
 
 .field-hint {
@@ -319,12 +357,73 @@ body {
   font-weight: 600;
 }
 
+/* ── Property characteristics cards ─────────────────── */
+#property-chars {
+  margin-top: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+
+.chars-section-label {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--gray-600);
+  margin: 0 0 10px;
+}
+
+.chars-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.char-item {
+  background: var(--gray-100);
+  border-radius: 6px;
+  padding: 10px 12px;
+}
+
+.char-item-value {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--blue);
+  margin-bottom: 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.char-item-label {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--gray-600);
+}
+
 /* ── Chart section ──────────────────────────────────── */
 #chart-section {
   grid-area: chart;
   background: var(--white);
   padding: 20px 24px;
   border-top: 3px solid var(--blue);
+}
+
+/* ── Breakdown section ──────────────────────────────── */
+#breakdown-section {
+  grid-area: breakdown;
+  background: var(--white);
+  padding: 20px 24px;
+  border-top: 3px solid var(--blue);
+}
+
+.breakdown-placeholder::before {
+  content: "Search for a property to view the value breakdown";
 }
 
 #chart-section h3,
@@ -434,6 +533,7 @@ body {
     grid-template:
       "info"
       "chart"
+      "breakdown"
       "table"
       / 1fr;
   }


### PR DESCRIPTION
# Description

Complete rebuild of both front-end interfaces (Tax Assessor Review and Property Owner Widget) and the main dashboard, implementing the full UI spec for issues #14–#19.

Resolves #14 #15 #16 #18 #19

## Type of change

- [x] New feature
- [x] Bug fix
- [ ] Small fix/change
- [ ] Documentation

## What should the reviewer know?

### Tax Assessor Review (`ui/reviewer/`)                                                                                                                                               
   
  **Map controls reorganized into two grouped panels:**                                                                                                                                  
  - Left panel: address search (with clear button) + zip code filter — both search tools together                                                                                      
  - Right panel: Map Layer selector + Highlight Discrepancies — both display controls together                                                                                           
                                                                                                                                                                                         
  **Zip code features:**                                                                                                                                                                 
  - Typing a zip code flies the map to that area (Census TIGER bounding box) and draws the zip boundary as a dashed polygon                                                              
  - New "Browse" button opens a zip selector panel listing all Philadelphia ZCTAs (191xx), loaded from Census TIGER API                                                                  
  - Hovering a zip in the list (or on the map) highlights its boundary; clicking zooms and selects it                                                                                    
                                                                                                                                                                                         
  **Stat cards updated:**                                                                                                                                                                
  - Residential parcels count (from tax year bins)                                                                                                                                       
  - Official median (from tax year bins)                                                                                                                                                 
  - ML predicted median — estimated from `tile_style_metadata.json` breakpoints midpoint; will become precise once `current_assessment_bins.json` is regenerated with ML data
  - Estimated market shift (ML vs official %)                                                                                                                                            
                                                                                                                                                                                         
  **Hover tooltip** now shows context-aware values based on the active map layer (tax year value, ML predicted, % change, or $ change).                                                  
                                                                                                                                                                                         
  **Popup** now includes a "View full history →" link that opens the Widget pre-loaded with that property.                                                                               
                                                            
  ---                                                                                                                                                                                    
                                                            
  ### Property Owner Widget (`ui/widget/`)                                                                                                                                               
   
  **New modules (no backend changes required):**                                                                                                                                         
  - **Property Characteristics cards** — year built, living area, property type, value per sq ft (from existing API response)
  - **Value Breakdown chart** — stacked bar showing taxable land vs. taxable building vs. exempt by year (ApexCharts, from existing assessment history)                                  
  - **Change annotations** on the market value chart — years with >10% YoY change are labeled in green/red                                                                               
                                                                                                                                                                                         
  **Address search fixes:**                                                                                                                                                              
  - Photon geocoder was returning full street names (e.g. "Pine Street") but OPA stores abbreviations ("PINE ST") — fixed by using only the first word of the street name for the search 
  string                                                                                                                                                                                 
  - Duplicate Photon suggestions (e.g. 6× "Park Towne Place") are now deduplicated; house number is extracted from the user's typed input when Photon doesn't return one
  - Added URL parameter loading: linking from Reviewer popup opens Widget with property pre-loaded (`?parcel_number=XXXXXXXXX`)                                                          
                                                                                                                                                                                         
  ---                                                                                                                                                                                    
                                                                                                                                                                                         
  ### Dashboard (`ui/index.html`)                           

  - Removed course/team badge ("MUSA 5090 · Team 6 · Spring 2026")                                                                                                                       
  - Tightened spacing so all content fits without scrolling on standard screens
  - Stats strip dynamically loads real counts and median from GCS bins                                                                                                                   
  - Card descriptions rewritten for each audience (assessors vs. property owners)                                                                                                        
                                                                                                                                                                                         
  ---                                                                                                                                                                                    
                                                                                                                                                                                         
  ### `tasks/property-lookup/`                                                                                                                                                           
   
  New Cloud Run Function backing the Widget's address search and property detail lookup, querying `core.opa_properties` and `core.opa_assessments` in BigQuery.

## Post-merge follow-ups

_Document any actions that must be taken post-merge to deploy or otherwise implement the changes in this PR (for example, running a `gcloud` command to upload to GCP)._

- [ ] No action required
- [ ] Actions required (specified below)
